### PR TITLE
Provide trigger to proactively push resources to the client

### DIFF
--- a/pkg/server/delta/v3/server.go
+++ b/pkg/server/delta/v3/server.go
@@ -34,6 +34,10 @@ type Callbacks interface {
 	OnStreamDeltaResponse(int64, *discovery.DeltaDiscoveryRequest, *discovery.DeltaDiscoveryResponse)
 }
 
+type ExtendedCallbacks interface {
+	OnStreamDeltaResponseF(int64, *discovery.DeltaDiscoveryRequest, *discovery.DeltaDiscoveryResponse, func(typeURL string, resourceNames []string))
+}
+
 var deltaErrorResponse = &cache.RawDeltaResponse{}
 
 type server struct {
@@ -72,6 +76,20 @@ func (s *server) processDelta(str stream.DeltaStream, reqCh <-chan *discovery.De
 		}
 	}()
 
+	// Sets up a watch in the cache
+	processWatch := func(newWatch watch, watchTypeURL string) {
+		newWatch.responses = make(chan cache.DeltaResponse, 1)
+		newWatch.cancel = s.cache.CreateDeltaWatch(newWatch.req, newWatch.state, newWatch.responses)
+		watches.deltaWatches[watchTypeURL] = newWatch
+
+		go func() {
+			resp, more := <-newWatch.responses
+			if more {
+				watches.deltaMuxedResponses <- resp
+			}
+		}()
+	}
+
 	// Sends a response, returns the new stream nonce
 	send := func(resp cache.DeltaResponse) (string, error) {
 		if resp == nil {
@@ -87,6 +105,26 @@ func (s *server) processDelta(str stream.DeltaStream, reqCh <-chan *discovery.De
 		response.Nonce = strconv.FormatInt(streamNonce, 10)
 		if s.callbacks != nil {
 			s.callbacks.OnStreamDeltaResponse(streamID, resp.GetDeltaRequest(), response)
+
+			if extendedCallbacks, ok := s.callbacks.(ExtendedCallbacks); ok {
+				extendedCallbacks.OnStreamDeltaResponseF(streamID, resp.GetDeltaRequest(), response, func(typeURL string, resourceNames []string) {
+					// cancel existing watch to (re-)request a newer version
+					watch, ok := watches.deltaWatches[typeURL]
+					if !ok {
+						// There's no existing watch
+						return
+					} else {
+						watch.Cancel()
+					}
+					for _, resourceName := range resourceNames {
+						// This will force an update for those resources
+						// If not existing it will return them as removed
+						watch.state.GetResourceVersions()[resourceName] = ""
+					}
+
+					processWatch(watch, typeURL)
+				})
+			}
 		}
 
 		return response.Nonce, str.Send(response)
@@ -158,6 +196,7 @@ func (s *server) processDelta(str stream.DeltaStream, reqCh <-chan *discovery.De
 
 			// cancel existing watch to (re-)request a newer version
 			watch, ok := watches.deltaWatches[typeURL]
+			watch.req = req
 			if !ok {
 				// Initialize the state of the stream.
 				// Since there was no previous state, we know we're handling the first request of this type
@@ -173,16 +212,7 @@ func (s *server) processDelta(str stream.DeltaStream, reqCh <-chan *discovery.De
 			s.subscribe(req.GetResourceNamesSubscribe(), &watch.state)
 			s.unsubscribe(req.GetResourceNamesUnsubscribe(), &watch.state)
 
-			watch.responses = make(chan cache.DeltaResponse, 1)
-			watch.cancel = s.cache.CreateDeltaWatch(req, watch.state, watch.responses)
-			watches.deltaWatches[typeURL] = watch
-
-			go func() {
-				resp, more := <-watch.responses
-				if more {
-					watches.deltaMuxedResponses <- resp
-				}
-			}()
+			processWatch(watch, typeURL)
 		}
 	}
 }

--- a/pkg/server/delta/v3/watches.go
+++ b/pkg/server/delta/v3/watches.go
@@ -35,6 +35,7 @@ type watch struct {
 	responses chan cache.DeltaResponse
 	cancel    func()
 	nonce     string
+	req       *cache.DeltaRequest
 
 	state stream.StreamState
 }

--- a/pkg/server/sotw/v3/watches.go
+++ b/pkg/server/sotw/v3/watches.go
@@ -7,6 +7,7 @@ import (
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
 	"github.com/envoyproxy/go-control-plane/pkg/cache/v3"
+	"github.com/envoyproxy/go-control-plane/pkg/server/stream/v3"
 )
 
 // watches for all xDS resource types
@@ -65,6 +66,9 @@ type watch struct {
 	cancel   func()
 	nonce    string
 	response chan cache.Response
+	req      *cache.Request
+
+	state stream.StreamState
 }
 
 // close cancels an open watch

--- a/pkg/server/v3/delta_test.go
+++ b/pkg/server/v3/delta_test.go
@@ -155,36 +155,36 @@ func makeMockDeltaStream(t *testing.T) *mockDeltaStream {
 
 func makeDeltaResources() map[string]map[string]types.Resource {
 	return map[string]map[string]types.Resource{
-		rsrc.EndpointType: map[string]types.Resource{
+		rsrc.EndpointType: {
 			endpoint.GetClusterName(): endpoint,
 		},
-		rsrc.ClusterType: map[string]types.Resource{
+		rsrc.ClusterType: {
 			cluster.Name: cluster,
 		},
-		rsrc.RouteType: map[string]types.Resource{
+		rsrc.RouteType: {
 			route.Name: route,
 		},
-		rsrc.ScopedRouteType: map[string]types.Resource{
+		rsrc.ScopedRouteType: {
 			scopedRoute.Name: scopedRoute,
 		},
-		rsrc.VirtualHostType: map[string]types.Resource{
+		rsrc.VirtualHostType: {
 			virtualHost.Name: virtualHost,
 		},
-		rsrc.ListenerType: map[string]types.Resource{
+		rsrc.ListenerType: {
 			httpListener.Name:       httpListener,
 			httpScopedListener.Name: httpScopedListener,
 		},
-		rsrc.SecretType: map[string]types.Resource{
+		rsrc.SecretType: {
 			secret.Name: secret,
 		},
-		rsrc.RuntimeType: map[string]types.Resource{
+		rsrc.RuntimeType: {
 			runtime.Name: runtime,
 		},
-		rsrc.ExtensionConfigType: map[string]types.Resource{
+		rsrc.ExtensionConfigType: {
 			extensionConfig.Name: extensionConfig,
 		},
 		// Pass-through type (types without explicit handling)
-		opaqueType: map[string]types.Resource{
+		opaqueType: {
 			"opaque": opaque,
 		},
 	}
@@ -461,7 +461,7 @@ func TestDeltaCallbackError(t *testing.T) {
 func TestDeltaWildcardSubscriptions(t *testing.T) {
 	config := makeMockConfigWatcher()
 	config.deltaResources = map[string]map[string]types.Resource{
-		rsrc.EndpointType: map[string]types.Resource{
+		rsrc.EndpointType: {
 			"endpoints0": resource.MakeEndpoint("endpoints0", 1234),
 			"endpoints1": resource.MakeEndpoint("endpoints1", 1234),
 			"endpoints2": resource.MakeEndpoint("endpoints2", 1234),
@@ -641,32 +641,35 @@ func TestDeltaCallbackTrigger(t *testing.T) {
 		triggerName: clusterName,
 	}
 
-	validateResponse := func(t *testing.T, resp *mockDeltaStream, expectedType string, expectedResources []string) {
+	validateResponse := func(t *testing.T, resp *mockDeltaStream, expectedType string, expectedResources []string) map[string]string {
 		t.Helper()
 		var response *discovery.DeltaDiscoveryResponse
 		select {
 		case <-time.After(5 * time.Second):
 			assert.Fail(t, "no response after 5s")
-			return
+			return nil
 		case response = <-resp.sent:
 		}
 		assert.Equal(t, expectedType, response.TypeUrl)
+		versionMap := map[string]string{}
 		if assert.Equal(t, len(expectedResources), len(response.Resources)) {
 			var names []string
 			for _, resource := range response.Resources {
 				names = append(names, resource.Name)
+				versionMap[resource.Name] = resource.Version
 			}
 			assert.ElementsMatch(t, names, expectedResources)
 		}
+		return versionMap
 	}
 
 	config.deltaResources = map[string]map[string]types.Resource{
-		rsrc.ClusterType: map[string]types.Resource{
+		rsrc.ClusterType: {
 			cluster.Name:   cluster,
 			"otherCluster": resource.MakeCluster(resource.Ads, "otherCluster"),
 			"thirdCluster": resource.MakeCluster(resource.Ads, "thirdCluster"),
 		},
-		rsrc.EndpointType: map[string]types.Resource{
+		rsrc.EndpointType: {
 			cluster.Name:   endpoint,
 			"otherCluster": resource.MakeEndpoint("otherCluster", 1234),
 		},
@@ -770,5 +773,65 @@ func TestDeltaCallbackTrigger(t *testing.T) {
 		validateResponse(t, resp, rsrc.ClusterType, []string{clusterName})
 		validateResponse(t, resp, rsrc.EndpointType, []string{"otherCluster"})
 		assert.Equal(t, 0, config.deltaWatches)
+	})
+
+	t.Run("Request for the triggered type is received later than the trigger", func(t *testing.T) {
+		resp := makeMockDeltaStream(t)
+		s := server.NewServer(context.Background(), config, &callback)
+		go func() {
+			err := s.DeltaAggregatedResources(resp)
+			assert.NoError(t, err)
+		}()
+
+		// Initial request to know the versions
+		resp.recv <- &discovery.DeltaDiscoveryRequest{
+			Node:                    node,
+			TypeUrl:                 rsrc.EndpointType,
+			ResourceNamesSubscribe:  []string{endpoint.ClusterName, "otherCluster"},
+			InitialResourceVersions: map[string]string{},
+		}
+		epVersions := validateResponse(t, resp, rsrc.EndpointType, []string{endpoint.ClusterName, "otherCluster"})
+
+		close(resp.recv)
+
+		// Reset the stream
+		resp = makeMockDeltaStream(t)
+		go func() {
+			err := s.DeltaAggregatedResources(resp)
+			assert.NoError(t, err)
+		}()
+		defer close(resp.recv)
+
+		// Run a wildcard cluster request. No endpoint response will be triggered (as there is currently no request)
+		resp.recv <- &discovery.DeltaDiscoveryRequest{
+			Node:    node,
+			TypeUrl: rsrc.ClusterType,
+		}
+		validateResponse(t, resp, rsrc.ClusterType, []string{clusterName, "otherCluster", "thirdCluster"})
+		assert.Equal(t, 0, config.deltaWatches)
+
+		// Now create a watch for endpoints passing the correct version
+		// This should still trigger a response for "otherCluster" only as the update was triggered by the previous cluster request
+		resp.recv <- &discovery.DeltaDiscoveryRequest{
+			Node:                    node,
+			TypeUrl:                 rsrc.EndpointType,
+			ResourceNamesSubscribe:  []string{endpoint.ClusterName, "otherCluster"},
+			InitialResourceVersions: epVersions,
+		}
+		// endpoint.ClusterName is not returned here as the version was the same
+		validateResponse(t, resp, rsrc.EndpointType, []string{"otherCluster"})
+
+		// Ensure further requests do not trigger unwanted updates
+		resp.recv <- &discovery.DeltaDiscoveryRequest{
+			TypeUrl:                rsrc.EndpointType,
+			ResponseNonce:          "2",
+			ResourceNamesSubscribe: nil,
+		}
+		select {
+		case <-resp.sent:
+			assert.Fail(t, "received a response when no version has changed")
+		case <-time.After(100 * time.Millisecond):
+			// Pass
+		}
 	})
 }

--- a/pkg/server/v3/delta_test.go
+++ b/pkg/server/v3/delta_test.go
@@ -255,6 +255,7 @@ func TestDeltaResponseHandlers(t *testing.T) {
 			s := server.NewServer(context.Background(), config, server.CallbackFuncs{})
 
 			resp := makeMockDeltaStream(t)
+			// This is a wildcard request since we don't specify a list of resource subscriptions
 			resourceNames := []string{}
 			for resourceName := range config.deltaResources[typ] {
 				resourceNames = append(resourceNames, resourceName)
@@ -612,5 +613,162 @@ func TestDeltaWildcardSubscriptions(t *testing.T) {
 		}
 		validateResponse(t, resp.sent, []string{"endpoints2"}, []string{"endpoints4"})
 	})
+}
 
+type testExtendedCallbacks struct {
+	server.CallbackFuncs
+	triggerType string
+	triggerName string
+}
+
+func (c testExtendedCallbacks) OnStreamDeltaResponseF(streamId int64, req *discovery.DeltaDiscoveryRequest, resp *discovery.DeltaDiscoveryResponse, updateTrigger func(typeURL string, resourceNames []string)) {
+	trigger := false
+	for _, res := range resp.GetResources() {
+		if res.Name == c.triggerName {
+			trigger = true
+			break
+		}
+	}
+	if trigger && req.TypeUrl == rsrc.ClusterType {
+		updateTrigger(c.triggerType, []string{"otherCluster"})
+	}
+}
+
+func TestDeltaCallbackTrigger(t *testing.T) {
+	config := makeMockConfigWatcher()
+	callback := testExtendedCallbacks{
+		triggerType: rsrc.ClusterType,
+		triggerName: clusterName,
+	}
+
+	validateResponse := func(t *testing.T, resp *mockDeltaStream, expectedType string, expectedResources []string) {
+		t.Helper()
+		var response *discovery.DeltaDiscoveryResponse
+		select {
+		case <-time.After(5 * time.Second):
+			assert.Fail(t, "no response after 5s")
+			return
+		case response = <-resp.sent:
+		}
+		assert.Equal(t, expectedType, response.TypeUrl)
+		if assert.Equal(t, len(expectedResources), len(response.Resources)) {
+			var names []string
+			for _, resource := range response.Resources {
+				names = append(names, resource.Name)
+			}
+			assert.ElementsMatch(t, names, expectedResources)
+		}
+	}
+
+	config.deltaResources = map[string]map[string]types.Resource{
+		rsrc.ClusterType: map[string]types.Resource{
+			cluster.Name:   cluster,
+			"otherCluster": resource.MakeCluster(resource.Ads, "otherCluster"),
+			"thirdCluster": resource.MakeCluster(resource.Ads, "thirdCluster"),
+		},
+		rsrc.EndpointType: map[string]types.Resource{
+			cluster.Name:   endpoint,
+			"otherCluster": resource.MakeEndpoint("otherCluster", 1234),
+		},
+	}
+
+	t.Run("Same url type", func(t *testing.T) {
+		resp := makeMockDeltaStream(t)
+		defer close(resp.recv)
+		s := server.NewServer(context.Background(), config, &callback)
+		go func() {
+			err := s.DeltaAggregatedResources(resp)
+			assert.NoError(t, err)
+		}()
+		resp.recv <- &discovery.DeltaDiscoveryRequest{
+			Node:                   node,
+			TypeUrl:                rsrc.ClusterType,
+			ResourceNamesSubscribe: []string{"otherCluster"},
+		}
+		validateResponse(t, resp, rsrc.ClusterType, []string{"otherCluster"})
+
+		resp.recv <- &discovery.DeltaDiscoveryRequest{
+			Node:                   node,
+			TypeUrl:                rsrc.ClusterType,
+			ResourceNamesSubscribe: []string{"otherCluster"},
+		}
+
+		// This will not return as we already have it at the correct version
+		resp.recv <- &discovery.DeltaDiscoveryRequest{
+			Node:                   node,
+			TypeUrl:                rsrc.ClusterType,
+			ResourceNamesSubscribe: []string{"thirdCluster"},
+		}
+		// Only return thirdCluster as otherCluster version has not changed
+		validateResponse(t, resp, rsrc.ClusterType, []string{"thirdCluster"})
+
+		// Now request clusterName, which will trigger the specific push
+		resp.recv <- &discovery.DeltaDiscoveryRequest{
+			Node:                   node,
+			TypeUrl:                rsrc.ClusterType,
+			ResourceNamesSubscribe: []string{clusterName},
+		}
+		// The first response only includes the requested cluster
+		validateResponse(t, resp, rsrc.ClusterType, []string{clusterName})
+
+		// The second response also includes the triggered update
+		// It should ideally not return the initial resource, but sadly this doesn't properly work when using the same type
+		validateResponse(t, resp, rsrc.ClusterType, []string{clusterName, "otherCluster"})
+
+		assert.Equal(t, 0, config.deltaWatches)
+	})
+
+	callback.triggerType = rsrc.EndpointType
+	t.Run("Different url type, no existing watch", func(t *testing.T) {
+		resp := makeMockDeltaStream(t)
+		defer close(resp.recv)
+		s := server.NewServer(context.Background(), config, &callback)
+		go func() {
+			err := s.DeltaAggregatedResources(resp)
+			assert.NoError(t, err)
+		}()
+
+		resp.recv <- &discovery.DeltaDiscoveryRequest{
+			Node:                   node,
+			TypeUrl:                rsrc.ClusterType,
+			ResourceNamesSubscribe: []string{clusterName},
+		}
+		validateResponse(t, resp, rsrc.ClusterType, []string{clusterName})
+		assert.Equal(t, 0, config.deltaWatches)
+	})
+
+	t.Run("Different url type, existing watch", func(t *testing.T) {
+		resp := makeMockDeltaStream(t)
+		defer close(resp.recv)
+		s := server.NewServer(context.Background(), config, &callback)
+		go func() {
+			err := s.DeltaAggregatedResources(resp)
+			assert.NoError(t, err)
+		}()
+
+		// Setup a watch for endpoints
+		resp.recv <- &discovery.DeltaDiscoveryRequest{
+			Node:                   node,
+			TypeUrl:                rsrc.EndpointType,
+			ResourceNamesSubscribe: []string{endpoint.ClusterName, "otherCluster"},
+		}
+		validateResponse(t, resp, rsrc.EndpointType, []string{endpoint.ClusterName, "otherCluster"})
+
+		resp.recv <- &discovery.DeltaDiscoveryRequest{
+			TypeUrl:                rsrc.EndpointType,
+			ResponseNonce:          "2",
+			ResourceNamesSubscribe: nil,
+		}
+		// Watch is setup now with the current version known
+
+		// Same call as above, but this time with an existing watch on eps for "otherCluster"
+		resp.recv <- &discovery.DeltaDiscoveryRequest{
+			Node:                   node,
+			TypeUrl:                rsrc.ClusterType,
+			ResourceNamesSubscribe: []string{clusterName},
+		}
+		validateResponse(t, resp, rsrc.ClusterType, []string{clusterName})
+		validateResponse(t, resp, rsrc.EndpointType, []string{"otherCluster"})
+		assert.Equal(t, 0, config.deltaWatches)
+	})
 }


### PR DESCRIPTION
This PR is adding a feature we use to workaround an [issue](https://github.com/envoyproxy/envoy/issues/13009) in envoy:
 - when a cluster is updated in envoy (e.g. during a cds update), if the load-balancing or connection part is touched, envoy creates a new cluster and requests endpoints for the given eds key (same is applicable if a new cluster is added)
 - if the eds key has already been requested by this client, a bug in the delta-ads implementation on envoy side will drop the request without returning any endpoint. As a consequence, the new cluster (or the updated one) will be left with no endpoints and envoy will log an error (mentioning a CLA stream timeout)

To work-around this issue, we are adding an extension allowing the user to trigger a "force" push of resources when a response is sent. This force-push has the given properties:
- the push can be for the same or another type. If for the same type user should be aware some resources may end up being sent twice in two consecutive type responses
- the push can refer to multiple resources but only one type. Attempting to call it multiple time _should_ work but is definitely not guaranteed
- the response with those resources will be sent **after** the current response. This is a guarantee and is critical for this workaround to work
- the resources will be sent if and only if they are subscribed to (either explicitly or through wildcard)
- if at the time of the trigger there is no watch for the given type, the request for a push is kept and will be applied on the first request of the type. It means initialVersions for the resource will be ignored if set, and it will therefore always be returned if known