### PR TITLE
[sotw][linear] Fix missing watch cleanup in linear cache for sotw watches subscribing to multiple resources

### DIFF
--- a/pkg/cache/v3/linear_test.go
+++ b/pkg/cache/v3/linear_test.go
@@ -40,7 +40,14 @@ func testResource(s string) types.Resource {
 
 func verifyResponse(t *testing.T, ch <-chan Response, version string, num int) {
 	t.Helper()
-	r := <-ch
+	var r Response
+	select {
+	case r = <-ch:
+	case <-time.After(1 * time.Second):
+		t.Error("failed to receive response after 1 second")
+		return
+	}
+
 	if r.GetRequest().GetTypeUrl() != testType {
 		t.Errorf("unexpected empty request type URL: %q", r.GetRequest().GetTypeUrl())
 	}
@@ -62,6 +69,9 @@ func verifyResponse(t *testing.T, ch <-chan Response, version string, num int) {
 	}
 	if out.GetTypeUrl() != testType {
 		t.Errorf("unexpected type URL: %q", out.GetTypeUrl())
+	}
+	if len(r.GetRequest().GetResourceNames()) != 0 && len(r.GetRequest().GetResourceNames()) < len(out.Resources) {
+		t.Errorf("received more resources (%d) than requested (%d)", len(r.GetRequest().GetResourceNames()), len(out.Resources))
 	}
 }
 
@@ -772,4 +782,82 @@ func TestLinearMixedWatches(t *testing.T) {
 
 	verifyResponse(t, w, c.getVersion(), 0)
 	verifyDeltaResponse(t, wd, nil, []string{"b"})
+}
+
+func TestLinearSotwWatches(t *testing.T) {
+	t.Run("watches are properly removed from all objects", func(t *testing.T) {
+		cache := NewLinearCache(testType)
+		a := &endpoint.ClusterLoadAssignment{ClusterName: "a"}
+		err := cache.UpdateResource("a", a)
+		require.NoError(t, err)
+		b := &endpoint.ClusterLoadAssignment{ClusterName: "b"}
+		err = cache.UpdateResource("b", b)
+		require.NoError(t, err)
+		assert.Equal(t, 2, cache.NumResources())
+
+		// A watch tracks three different objects.
+		// An update is done for the three objects in a row
+		// If the watches are no properly purged, all three updates will send responses in the channel, but only the first one is tracked
+		// The buffer will therefore saturate and the third request will deadlock the entire cache as occurring under the mutex
+		sotwState := stream.NewStreamState(false, nil)
+		w := make(chan Response, 1)
+		_ = cache.CreateWatch(&Request{ResourceNames: []string{"a", "b", "c"}, TypeUrl: testType, VersionInfo: cache.getVersion()}, sotwState, w)
+		mustBlock(t, w)
+		checkVersionMapNotSet(t, cache)
+
+		assert.Len(t, cache.watches["a"], 1)
+		assert.Len(t, cache.watches["b"], 1)
+		assert.Len(t, cache.watches["c"], 1)
+
+		// Update a and c without touching b
+		a = &endpoint.ClusterLoadAssignment{ClusterName: "a", Endpoints: []*endpoint.LocalityLbEndpoints{ // resource update
+			{Priority: 25},
+		}}
+		err = cache.UpdateResources(map[string]types.Resource{"a": a}, nil)
+		require.NoError(t, err)
+		verifyResponse(t, w, cache.getVersion(), 1)
+		checkVersionMapNotSet(t, cache)
+
+		assert.Empty(t, cache.watches["a"])
+		assert.Empty(t, cache.watches["b"])
+		assert.Empty(t, cache.watches["c"])
+
+		// c no longer watched
+		w = make(chan Response, 1)
+		_ = cache.CreateWatch(&Request{ResourceNames: []string{"a", "b"}, TypeUrl: testType, VersionInfo: cache.getVersion()}, sotwState, w)
+		require.NoError(t, err)
+		mustBlock(t, w)
+		checkVersionMapNotSet(t, cache)
+
+		b = &endpoint.ClusterLoadAssignment{ClusterName: "b", Endpoints: []*endpoint.LocalityLbEndpoints{ // resource update
+			{Priority: 15},
+		}}
+		err = cache.UpdateResources(map[string]types.Resource{"b": b}, nil)
+
+		assert.Empty(t, cache.watches["a"])
+		assert.Empty(t, cache.watches["b"])
+		assert.Empty(t, cache.watches["c"])
+
+		require.NoError(t, err)
+		verifyResponse(t, w, cache.getVersion(), 1)
+		checkVersionMapNotSet(t, cache)
+
+		w = make(chan Response, 1)
+		_ = cache.CreateWatch(&Request{ResourceNames: []string{"c"}, TypeUrl: testType, VersionInfo: cache.getVersion()}, sotwState, w)
+		require.NoError(t, err)
+		mustBlock(t, w)
+		checkVersionMapNotSet(t, cache)
+
+		c := &endpoint.ClusterLoadAssignment{ClusterName: "c", Endpoints: []*endpoint.LocalityLbEndpoints{ // resource update
+			{Priority: 15},
+		}}
+		err = cache.UpdateResources(map[string]types.Resource{"c": c}, nil)
+		require.NoError(t, err)
+		verifyResponse(t, w, cache.getVersion(), 1)
+		checkVersionMapNotSet(t, cache)
+
+		assert.Empty(t, cache.watches["a"])
+		assert.Empty(t, cache.watches["b"])
+		assert.Empty(t, cache.watches["c"])
+	})
 }


### PR DESCRIPTION
Datadog-branch specific PR for https://github.com/envoyproxy/go-control-plane/pull/854

When using the linear cache in sotw mode, there are multiple issues when using non-wildcard requests
This PR addresses two issues potentially impactful:
 - the request provided to callbacks and the servers is a fake one not including the actual data. This is confusing and can generate issues (e.g. the node section is nil while user might expect it set when using the simple cache)
 - if the request is not wildcard, the cache stores the watch for each requested resource, but only clear it from the updated resources, leaving stale channels potentially full. If two updates come prior to the server consuming the channel or closing it fully, the code will block on the channel under the mutex and the server calling CreateWatch will also deadlock. As this mutex is common to all nodes the entire cache would then be deadlocked. The current implementation of sotw server makes it unlikely except if multiple updates are sent to the cache (e.g. iterating on UpdateResource instead of using UpdateResources). Any server implementation which would consider a watch properly cleaned if triggered (which is the initial design of the cache interface) would leak the channel and potentially trigger a deadlock later on

Other issues are not yet tackled in this PR as they depend for some on changes in the cache interface proposed in other PRs
 - properly trigger watches when a new resource is requested in the request but the version is unchanged
 - support for explicit wildcard request

Other issues to be addressed in other PRs
 - resource ordering when using Mux Cache in ADS mode
 - full updates or partial updates in sotw depending on resource type (lds/cds with full update, partial for rds/eds) and not on cache/protocol type (current implementation)