### PR TITLE
Ensure subscription is properly updated for sotw and delta

### DIFF
--- a/pkg/cache/v3/simple.go
+++ b/pkg/cache/v3/simple.go
@@ -224,6 +224,7 @@ func (cache *snapshotCache) SetSnapshot(ctx context.Context, node string, snapsh
 	cache.mu.Lock()
 	defer cache.mu.Unlock()
 
+	cache.log.Debugf("setting snapshot for node %s", node)
 	// update the existing entry
 	cache.snapshots[node] = snapshot
 

--- a/pkg/integration/ttl_integration_test.go
+++ b/pkg/integration/ttl_integration_test.go
@@ -19,7 +19,9 @@ import (
 	endpointservice "github.com/envoyproxy/go-control-plane/envoy/service/endpoint/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
 	"github.com/envoyproxy/go-control-plane/pkg/cache/v3"
+	"github.com/envoyproxy/go-control-plane/pkg/log"
 	"github.com/envoyproxy/go-control-plane/pkg/resource/v3"
+	"github.com/envoyproxy/go-control-plane/pkg/server/sotw/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/server/v3"
 )
 
@@ -37,7 +39,7 @@ func TestTTLResponse(t *testing.T) {
 	defer cancel()
 
 	snapshotCache := cache.NewSnapshotCacheWithHeartbeating(ctx, false, cache.IDHash{}, logger{t: t}, time.Second)
-	server := server.NewServer(ctx, snapshotCache, nil)
+	server := server.NewServer(ctx, snapshotCache, nil, sotw.WithLogger(log.NewTestLogger(t)))
 	grpcServer := grpc.NewServer()
 	endpointservice.RegisterEndpointDiscoveryServiceServer(grpcServer, server)
 

--- a/pkg/log/test.go
+++ b/pkg/log/test.go
@@ -14,20 +14,24 @@ func NewTestLogger(t testing.TB) Logger {
 
 // Debugf logs a message at level debug on the test logger.
 func (l testLogger) Debugf(msg string, args ...interface{}) {
+	l.t.Helper()
 	l.t.Logf("[debug] "+msg, args...)
 }
 
 // Infof logs a message at level info on the test logger.
 func (l testLogger) Infof(msg string, args ...interface{}) {
+	l.t.Helper()
 	l.t.Logf("[info] "+msg, args...)
 }
 
 // Warnf logs a message at level warn on the test logger.
 func (l testLogger) Warnf(msg string, args ...interface{}) {
+	l.t.Helper()
 	l.t.Logf("[warn] "+msg, args...)
 }
 
 // Errorf logs a message at level error on the test logger.
 func (l testLogger) Errorf(msg string, args ...interface{}) {
+	l.t.Helper()
 	l.t.Logf("[error] "+msg, args...)
 }

--- a/pkg/server/config/config.go
+++ b/pkg/server/config/config.go
@@ -1,15 +1,20 @@
 package config
 
+import "github.com/envoyproxy/go-control-plane/pkg/log"
+
 // Opts for individual xDS implementations that can be
 // utilized through the functional opts pattern.
 type Opts struct {
 	// If true respond to ADS requests with a guaranteed resource ordering
 	Ordered bool
+
+	Logger log.Logger
 }
 
 func NewOpts() Opts {
 	return Opts{
 		Ordered: false,
+		Logger:  log.NewDefaultLogger(),
 	}
 }
 

--- a/pkg/server/delta/v3/server.go
+++ b/pkg/server/delta/v3/server.go
@@ -212,19 +212,22 @@ func (s *server) processDelta(str stream.DeltaStream, reqCh <-chan *discovery.De
 			// cancel existing watch to (re-)request a newer version
 			watch, ok := watches.deltaWatches[typeURL]
 			if !ok {
-				// Initialize the state of the stream.
-				// Since there was no previous state, we know we're handling the first request of this type
+				// Initialize the state of the type subscription.
+				// Since there was no previous subscription, we know we're handling the first request of this type
 				// so we set the initial resource versions if we have any.
-				// We also set the stream as wildcard based on its legacy meaning (no resource name sent in resource_names_subscribe).
-				// If the state starts with this legacy mode, adding new resources will not unsubscribe from wildcard.
+				// We also set the subscription as wildcard based on its legacy meaning (no resource name sent in resource_names_subscribe).
+				// If the subscription starts with this legacy mode, adding new resources will not unsubscribe from wildcard.
 				// It can still be done by explicitly unsubscribing from "*"
-				watch.subscription = stream.NewSubscription(len(req.GetResourceNamesSubscribe()) == 0, req.GetInitialResourceVersions())
+				watch.subscription = stream.NewDeltaSubscription(req.GetResourceNamesSubscribe(), req.GetResourceNamesUnsubscribe(), req.GetInitialResourceVersions())
 			} else {
 				watch.Cancel()
-			}
 
-			s.subscribe(req.GetResourceNamesSubscribe(), &watch.subscription)
-			s.unsubscribe(req.GetResourceNamesUnsubscribe(), &watch.subscription)
+				// Update subscription with the new requests
+				watch.subscription.UpdateResourceSubscriptions(
+					req.GetResourceNamesSubscribe(),
+					req.GetResourceNamesUnsubscribe(),
+				)
+			}
 
 			var err error
 			watch.cancel, err = s.cache.CreateDeltaWatch(req, watch.subscription, watches.deltaMuxedResponses)
@@ -260,41 +263,4 @@ func (s *server) DeltaStreamHandler(str stream.DeltaStream, typeURL string) erro
 	}()
 
 	return s.processDelta(str, reqCh, typeURL)
-}
-
-// When we subscribe, we just want to make the cache know we are subscribing to a resource.
-// Even if the stream is wildcard, we keep the list of explicitly subscribed resources as the wildcard subscription can be discarded later on.
-func (s *server) subscribe(resources []string, subscription *stream.Subscription) {
-	sv := subscription.SubscribedResources()
-	for _, resource := range resources {
-		if resource == "*" {
-			subscription.SetWildcard(true)
-			continue
-		}
-		sv[resource] = struct{}{}
-	}
-}
-
-// unsubscribe remove resources from the stream's subscribed resource list.
-// If a client explicitly unsubscribes from a wildcard request, the stream is updated and now watches only subscribed resources.
-func (s *server) unsubscribe(resources []string, subscription *stream.Subscription) {
-	sv := subscription.SubscribedResources()
-	for _, resource := range resources {
-		if resource == "*" {
-			subscription.SetWildcard(false)
-			continue
-		}
-		if _, ok := sv[resource]; ok && subscription.IsWildcard() {
-			// The XDS protocol states that:
-			// * if a watch is currently wildcard
-			// * a resource is explicitly unsubscribed by name
-			// Then the control-plane must return in the response whether the resource is removed (if no longer present for this node)
-			// or still existing. In the latter case the entire resource must be returned, same as if it had been created or updated
-			// To achieve that, we mark the resource as having been returned with an empty version. While creating the response, the cache will either:
-			// * detect the version change, and return the resource (as an update)
-			// * detect the resource deletion, and set it as removed in the response
-			subscription.ReturnedResources()[resource] = ""
-		}
-		delete(sv, resource)
-	}
 }

--- a/pkg/server/delta/v3/server.go
+++ b/pkg/server/delta/v3/server.go
@@ -12,6 +12,7 @@ import (
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/cache/v3"
+	"github.com/envoyproxy/go-control-plane/pkg/log"
 	"github.com/envoyproxy/go-control-plane/pkg/resource/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/server/config"
 	"github.com/envoyproxy/go-control-plane/pkg/server/stream/v3"
@@ -47,6 +48,13 @@ type server struct {
 
 	// Local configuration flags for individual xDS implementations.
 	opts config.Opts
+}
+
+// WithLogger configures the server logger. Defaults to no logging
+func WithLogger(logger log.Logger) config.XDSOption {
+	return func(o *config.Opts) {
+		o.Logger = logger
+	}
 }
 
 // NewServer creates a delta xDS specific server which utilizes a ConfigWatcher and delta Callbacks.

--- a/pkg/server/sotw/v3/ads.go
+++ b/pkg/server/sotw/v3/ads.go
@@ -7,30 +7,13 @@ import (
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
 	"github.com/envoyproxy/go-control-plane/pkg/cache/v3"
-	"github.com/envoyproxy/go-control-plane/pkg/resource/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/server/stream/v3"
 )
 
 // process handles a bi-di stream request
-func (s *server) processADS(sw *streamWrapper, reqCh chan *discovery.DiscoveryRequest, defaultTypeURL string) error {
-	// We make a responder channel here so we can multiplex responses from the dynamic channels.
-	sw.watches.addWatch(resource.AnyType, &watch{
-		// Create a buffered channel the size of the known resource types.
-		response: make(chan cache.Response, types.UnknownType),
-		cancel: func() {
-			close(sw.watches.responders[resource.AnyType].response)
-		},
-	})
-
-	process := func(resp cache.Response) error {
-		nonce, err := sw.send(resp)
-		if err != nil {
-			return err
-		}
-
-		sw.watches.responders[resp.GetRequest().GetTypeUrl()].nonce = nonce
-		return nil
-	}
+func (s *server) processADS(sw *streamWrapper, reqCh chan *discovery.DiscoveryRequest) error {
+	// Create a buffered multiplexed channel the size of the known resource types.
+	respChan := make(chan cache.Response, types.UnknownType)
 
 	// Instead of creating a separate channel for each incoming request and abandoning the old one
 	// This algorithm uses (and reuses) a single channel for all request types and guarantees
@@ -43,9 +26,9 @@ func (s *server) processADS(sw *streamWrapper, reqCh chan *discovery.DiscoveryRe
 		for {
 			select {
 			// We watch the multiplexed ADS channel for incoming responses.
-			case res := <-sw.watches.responders[resource.AnyType].response:
+			case res := <-respChan:
 				if res.GetRequest().GetTypeUrl() != typeURL {
-					if err := process(res); err != nil {
+					if err := sw.send(res); err != nil {
 						return err
 					}
 				}
@@ -63,9 +46,9 @@ func (s *server) processADS(sw *streamWrapper, reqCh chan *discovery.DiscoveryRe
 		select {
 		case <-s.ctx.Done():
 			return nil
-		// We only watch the multiplexed channel since all values will come through from process.
-		case res := <-sw.watches.responders[resource.AnyType].response:
-			if err := process(res); err != nil {
+		// We only watch the multiplexed channel since we don't use per watch channels.
+		case res := <-respChan:
+			if err := sw.send(res); err != nil {
 				return status.Errorf(codes.Unavailable, err.Error())
 			}
 		case req, ok := <-reqCh:
@@ -86,14 +69,10 @@ func (s *server) processADS(sw *streamWrapper, reqCh chan *discovery.DiscoveryRe
 				req.Node = sw.node
 			}
 
-			// Nonces can be reused across streams; we verify nonce only if nonce is not initialized.
-			nonce := req.GetResponseNonce()
-
 			// type URL is required for ADS but is implicit for xDS
-			if defaultTypeURL == resource.AnyType {
-				if req.GetTypeUrl() == "" {
-					return status.Errorf(codes.InvalidArgument, "type URL is required for ADS")
-				}
+			typeURL := req.GetTypeUrl()
+			if typeURL == "" {
+				return status.Errorf(codes.InvalidArgument, "type URL is required for ADS")
 			}
 
 			if s.callbacks != nil {
@@ -102,55 +81,44 @@ func (s *server) processADS(sw *streamWrapper, reqCh chan *discovery.DiscoveryRe
 				}
 			}
 
-			typeURL := req.GetTypeUrl()
-			subscription, ok := sw.subscriptions[typeURL]
-			if !ok {
-				subscription = stream.NewSubscription(len(req.GetResourceNames()) == 0, nil)
-			}
-
-			if lastResponse, ok := sw.lastDiscoveryResponses[req.GetTypeUrl()]; ok {
-				if lastResponse.nonce == "" || lastResponse.nonce == nonce {
-					// Let's record Resource names that a client has received.
-					subscription.SetReturnedResources(lastResponse.resources)
+			var subscription stream.Subscription
+			w, ok := sw.watches.responders[typeURL]
+			if ok {
+				if w.nonce != "" && req.GetResponseNonce() != w.nonce {
+					// The request does not match the stream nonce, ignore it as per
+					// https://www.envoyproxy.io/docs/envoy/v1.28.0/api-docs/xds_protocol#resource-updates
+					// Ignore this request and wait for the next one
+					// This behavior is being discussed in https://github.com/envoyproxy/envoy/issues/10363
+					// as it might create a race in edge cases, but it matches the current protocol definition
+					s.opts.Logger.Infof("[sotw ads] Skipping request as nonce is stale for %s", typeURL)
+					break
 				}
-			}
 
-			// Use the multiplexed channel for new watches.
-			responder := sw.watches.responders[resource.AnyType].response
-			if w, ok := sw.watches.responders[typeURL]; ok {
-				// We've found a pre-existing watch, lets check and update if needed.
-				// If these requirements aren't satisfied, leave an open watch.
-				if w.nonce == "" || w.nonce == nonce {
-					w.close()
+				// We found an existing watch
+				// Close it to ensure the Cache will not reply to it while we modify the subscription state
+				w.close()
 
-					// Only process if we have an existing watch otherwise go ahead and create.
-					if err := processAllExcept(typeURL); err != nil {
-						return err
-					}
-
-					cancel, err := s.cache.CreateWatch(req, subscription, responder)
-					if err != nil {
-						return err
-					}
-					sw.watches.addWatch(typeURL, &watch{
-						cancel:   cancel,
-						response: responder,
-					})
-				}
-			} else {
-				// No pre-existing watch exists, let's create one.
-				// We need to precompute the watches first then open a watch in the cache.
-				cancel, err := s.cache.CreateWatch(req, subscription, responder)
-				if err != nil {
+				// Only process if we have an existing watch otherwise go ahead and create.
+				if err := processAllExcept(typeURL); err != nil {
 					return err
 				}
-				sw.watches.addWatch(typeURL, &watch{
-					cancel:   cancel,
-					response: responder,
-				})
+
+				subscription = w.sub
+				subscription.SetResourceSubscription(req.GetResourceNames())
+			} else {
+				s.opts.Logger.Debugf("[sotw ads] New subscription for type %s and stream %d", typeURL, sw.ID)
+				subscription = stream.NewSotwSubscription(req.GetResourceNames())
 			}
 
-			sw.subscriptions[typeURL] = subscription
+			cancel, err := s.cache.CreateWatch(req, subscription, respChan)
+			if err != nil {
+				return err
+			}
+			sw.watches.addWatch(typeURL, &watch{
+				cancel:   cancel,
+				response: respChan,
+				sub:      subscription,
+			})
 		}
 	}
 }

--- a/pkg/server/sotw/v3/server.go
+++ b/pkg/server/sotw/v3/server.go
@@ -24,6 +24,7 @@ import (
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/cache/v3"
+	"github.com/envoyproxy/go-control-plane/pkg/log"
 	"github.com/envoyproxy/go-control-plane/pkg/server/config"
 	"github.com/envoyproxy/go-control-plane/pkg/server/stream/v3"
 )
@@ -62,6 +63,13 @@ func NewServer(ctx context.Context, cw cache.ConfigWatcher, callbacks Callbacks,
 func WithOrderedADS() config.XDSOption {
 	return func(o *config.Opts) {
 		o.Ordered = true
+	}
+}
+
+// WithLogger configures the server logger. Defaults to no logging
+func WithLogger(logger log.Logger) config.XDSOption {
+	return func(o *config.Opts) {
+		o.Logger = logger
 	}
 }
 

--- a/pkg/server/sotw/v3/server.go
+++ b/pkg/server/sotw/v3/server.go
@@ -18,6 +18,7 @@ package sotw
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strconv"
 	"sync/atomic"
 
@@ -96,48 +97,49 @@ type streamWrapper struct {
 	callbacks Callbacks     // callbacks for performing actions through stream lifecycle
 
 	node *core.Node // registered xDS client
-
-	// The below fields are used for tracking resource
-	// cache state and should be maintained per stream.
-	subscriptions          map[string]stream.Subscription
-	lastDiscoveryResponses map[string]lastDiscoveryResponse
 }
 
 // Send packages the necessary resources before sending on the gRPC stream,
 // and sets the current state of the world.
-func (s *streamWrapper) send(resp cache.Response) (string, error) {
+func (s *streamWrapper) send(resp cache.Response) error {
 	if resp == nil {
-		return "", errors.New("missing response")
+		return errors.New("missing response")
 	}
 
 	out, err := resp.GetDiscoveryResponse()
 	if err != nil {
-		return "", err
+		return err
 	}
 
 	// increment nonce and convert it to base10
 	out.Nonce = strconv.FormatInt(atomic.AddInt64(&s.nonce, 1), 10)
 
-	version, err := resp.GetVersion()
-	if err != nil {
-		return "", err
+	typeURL := resp.GetRequest().GetTypeUrl()
+	w, ok := s.watches.responders[typeURL]
+	if !ok {
+		return fmt.Errorf("no current watch for %s", typeURL)
 	}
 
-	lastResponse := lastDiscoveryResponse{
-		nonce:     out.GetNonce(),
-		resources: make(map[string]string),
+	// Track in the type subcription the nonce and objects returned to the client.
+	version, err := resp.GetVersion()
+	if err != nil {
+		return err
 	}
+	// ToDo(valerian-roche): properly return the resources actually sent to the client
+	// Currently we set all resources requested, which is non-descriptive when using wildcard.
+	resources := make(map[string]string, len(resp.GetRequest().GetResourceNames()))
 	for _, r := range resp.GetRequest().GetResourceNames() {
-		lastResponse.resources[r] = version
+		resources[r] = version
 	}
-	s.lastDiscoveryResponses[resp.GetRequest().GetTypeUrl()] = lastResponse
+	w.sub.SetReturnedResources(resources)
+	w.nonce = out.Nonce
 
 	// Register with the callbacks provided that we are sending the response.
 	if s.callbacks != nil {
 		s.callbacks.OnStreamResponse(resp.GetContext(), s.ID, resp.GetRequest(), out)
 	}
 
-	return out.GetNonce(), s.stream.Send(out)
+	return s.stream.Send(out)
 }
 
 // Shutdown closes all open watches, and notifies API consumers the stream has closed.
@@ -146,15 +148,6 @@ func (s *streamWrapper) shutdown() {
 	if s.callbacks != nil {
 		s.callbacks.OnStreamClosed(s.ID, s.node)
 	}
-}
-
-// Discovery response that is sent over GRPC stream.
-// We need to record what resource names are already sent to a client
-// So if the client requests a new name we can respond back
-// regardless current snapshot version (even if it is not changed yet)
-type lastDiscoveryResponse struct {
-	nonce     string
-	resources map[string]string
 }
 
 // StreamHandler converts a blocking read call to channels and initiates stream processing

--- a/pkg/server/sotw/v3/watches.go
+++ b/pkg/server/sotw/v3/watches.go
@@ -7,6 +7,7 @@ import (
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
 	"github.com/envoyproxy/go-control-plane/pkg/cache/v3"
+	"github.com/envoyproxy/go-control-plane/pkg/server/stream/v3"
 )
 
 // watches for all xDS resource types
@@ -63,8 +64,11 @@ func (w *watches) recompute(ctx context.Context, req <-chan *discovery.Discovery
 // watch contains the necessary modifiable data for receiving resource responses
 type watch struct {
 	cancel   func()
-	nonce    string
 	response chan cache.Response
+
+	sub stream.Subscription
+	// Nonce of the latest response sent for this type
+	nonce string
 }
 
 // close cancels an open watch

--- a/pkg/server/sotw/v3/xds.go
+++ b/pkg/server/sotw/v3/xds.go
@@ -26,9 +26,7 @@ func (s *server) process(str stream.Stream, reqCh chan *discovery.DiscoveryReque
 		node:      &core.Node{}, // node may only be set on the first discovery request
 
 		// a collection of stack allocated watches per request type.
-		watches:                newWatches(),
-		subscriptions:          make(map[string]stream.Subscription),
-		lastDiscoveryResponses: make(map[string]lastDiscoveryResponse),
+		watches: newWatches(),
 	}
 
 	// cleanup once our stream has ended.
@@ -38,6 +36,22 @@ func (s *server) process(str stream.Stream, reqCh chan *discovery.DiscoveryReque
 		if err := s.callbacks.OnStreamOpen(str.Context(), sw.ID, defaultTypeURL); err != nil {
 			return err
 		}
+	}
+
+	// type URL is required for ADS but is implicit for xDS
+	if defaultTypeURL == resource.AnyType && s.opts.Ordered {
+		// When using ADS we need to order responses.
+		// This is guaranteed in the xDS protocol specification
+		// as ADS is required to be eventually consistent.
+		// More details can be found here if interested:
+		// https://www.envoyproxy.io/docs/envoy/latest/api-docs/xds_protocol#eventual-consistency-considerations
+
+		// Trigger a different code path specifically for ADS.
+		// We want resource ordering so things don't get sent before they should.
+		// This is a blocking call and will exit the process function
+		// on successful completion.
+		s.opts.Logger.Debugf("[sotw] Switching to ordered ADS implementation for stream %d", sw.ID)
+		return s.processADS(&sw, reqCh)
 	}
 
 	// do an initial recompute so we can load the first 2 channels:
@@ -66,6 +80,7 @@ func (s *server) process(str stream.Stream, reqCh chan *discovery.DiscoveryReque
 
 			req := value.Interface().(*discovery.DiscoveryRequest)
 			if req == nil {
+				s.opts.Logger.Debugf("[sotw] Rejecting empty request for stream %d", sw.ID)
 				return status.Errorf(codes.Unavailable, "empty request")
 			}
 
@@ -76,37 +91,12 @@ func (s *server) process(str stream.Stream, reqCh chan *discovery.DiscoveryReque
 				req.Node = sw.node
 			}
 
-			// nonces can be reused across streams; we verify nonce only if nonce is not initialized
-			nonce := req.GetResponseNonce()
-
 			// type URL is required for ADS but is implicit for xDS
-			if defaultTypeURL == resource.AnyType {
-				if req.GetTypeUrl() == "" {
-					return status.Errorf(codes.InvalidArgument, "type URL is required for ADS")
-				}
-
-				// When using ADS we need to order responses.
-				// This is guaranteed in the xDS protocol specification
-				// as ADS is required to be eventually consistent.
-				// More details can be found here if interested:
-				// https://www.envoyproxy.io/docs/envoy/latest/api-docs/xds_protocol#eventual-consistency-considerations
-				if s.opts.Ordered {
-					// send our first request on the stream again so it doesn't get
-					// lost in processing on the new control loop
-					// There's a risk (albeit very limited) that we'd end up handling requests in the wrong order here.
-					// If envoy is using ADS for endpoints, and clusters are added in short sequence,
-					// the following request might include a new cluster and be discarded as the previous one will be handled after.
-					go func() {
-						reqCh <- req
-					}()
-
-					// Trigger a different code path specifically for ADS.
-					// We want resource ordering so things don't get sent before they should.
-					// This is a blocking call and will exit the process function
-					// on successful completion.
-					return s.processADS(&sw, reqCh, defaultTypeURL)
-				}
-			} else if req.GetTypeUrl() == "" {
+			switch {
+			case defaultTypeURL == resource.AnyType && req.GetTypeUrl() == "":
+				s.opts.Logger.Debugf("[sotw] Rejecting request as missing URL for stream %d", sw.ID)
+				return status.Errorf(codes.InvalidArgument, "type URL is required for ADS")
+			case req.GetTypeUrl() == "":
 				req.TypeUrl = defaultTypeURL
 			}
 
@@ -117,48 +107,41 @@ func (s *server) process(str stream.Stream, reqCh chan *discovery.DiscoveryReque
 			}
 
 			typeURL := req.GetTypeUrl()
-			subscription, ok := sw.subscriptions[typeURL]
-			if !ok {
-				subscription = stream.NewSubscription(len(req.GetResourceNames()) == 0, nil)
-			}
-
-			if lastResponse, ok := sw.lastDiscoveryResponses[req.GetTypeUrl()]; ok {
-				if lastResponse.nonce == "" || lastResponse.nonce == nonce {
-					// Let's record Resource names that a client has received.
-					subscription.SetReturnedResources(lastResponse.resources)
+			var subscription stream.Subscription
+			w, ok := sw.watches.responders[typeURL]
+			if ok {
+				if w.nonce != "" && req.GetResponseNonce() != w.nonce {
+					// The request does not match the stream nonce, ignore it as per
+					// https://www.envoyproxy.io/docs/envoy/v1.28.0/api-docs/xds_protocol#resource-updates
+					// Ignore this request and wait for the next one
+					// This behavior is being discussed in https://github.com/envoyproxy/envoy/issues/10363
+					// as it might create a race in edge cases, but it matches the current protocol definition
+					s.opts.Logger.Infof("[sotw] Skipping request as nonce is stale for type %s and stream %d", typeURL, sw.ID)
+					break
 				}
+
+				// We found an existing watch
+				// Close it to ensure the Cache will not reply to it while we modify the subscription state
+				w.close()
+
+				subscription = w.sub
+				subscription.SetResourceSubscription(req.GetResourceNames())
+			} else {
+				s.opts.Logger.Debugf("[sotw] New subscription for type %s and stream %d", typeURL, sw.ID)
+				subscription = stream.NewSotwSubscription(req.GetResourceNames())
 			}
 
 			responder := make(chan cache.Response, 1)
-			if w, ok := sw.watches.responders[typeURL]; ok {
-				// We've found a pre-existing watch, lets check and update if needed.
-				// If these requirements aren't satisfied, leave an open watch.
-				if w.nonce == "" || w.nonce == nonce {
-					w.close()
-
-					cancel, err := s.cache.CreateWatch(req, subscription, responder)
-					if err != nil {
-						return err
-					}
-					sw.watches.addWatch(typeURL, &watch{
-						cancel:   cancel,
-						response: responder,
-					})
-				}
-			} else {
-				// No pre-existing watch exists, let's create one.
-				// We need to precompute the watches first then open a watch in the cache.
-				cancel, err := s.cache.CreateWatch(req, subscription, responder)
-				if err != nil {
-					return err
-				}
-				sw.watches.addWatch(typeURL, &watch{
-					cancel:   cancel,
-					response: responder,
-				})
+			cancel, err := s.cache.CreateWatch(req, subscription, responder)
+			if err != nil {
+				s.opts.Logger.Warnf("[sotw] Watch rejected for type %s and stream %d", typeURL, sw.ID)
+				return err
 			}
-
-			sw.subscriptions[typeURL] = subscription
+			sw.watches.addWatch(typeURL, &watch{
+				cancel:   cancel,
+				response: responder,
+				sub:      subscription,
+			})
 
 			// Recompute the dynamic select cases for this stream.
 			sw.watches.recompute(s.ctx, reqCh)
@@ -170,12 +153,10 @@ func (s *server) process(str stream.Stream, reqCh chan *discovery.DiscoveryReque
 			}
 
 			res := value.Interface().(cache.Response)
-			nonce, err := sw.send(res)
+			err := sw.send(res)
 			if err != nil {
 				return err
 			}
-
-			sw.watches.responders[res.GetRequest().GetTypeUrl()].nonce = nonce
 		}
 	}
 }

--- a/pkg/server/stream/v3/subscription.go
+++ b/pkg/server/stream/v3/subscription.go
@@ -1,9 +1,19 @@
 package stream
 
+const (
+	explicitWildcard = "*"
+)
+
 // Subscription stores the server view of a given type subscription in a stream.
 type Subscription struct {
 	// wildcard indicates if the subscription currently has a wildcard watch.
 	wildcard bool
+
+	// allowLegacyWildcard indicates that the stream never provided any resource
+	// and is de facto wildcard.
+	// As soon as a resource or an explicit subscription to wildcard is provided,
+	// this flag will be set to false
+	allowLegacyWildcard bool
 
 	// subscribedResourceNames provides the resources explicitly requested by the client
 	// This list might be non-empty even when set as wildcard.
@@ -13,10 +23,11 @@ type Subscription struct {
 	returnedResources map[string]string
 }
 
-// NewSubscription initializes a subscription state.
-func NewSubscription(wildcard bool, initialResourceVersions map[string]string) Subscription {
+// newSubscription initializes a subscription state.
+func newSubscription(wildcard bool, initialResourceVersions map[string]string) Subscription {
 	state := Subscription{
 		wildcard:                wildcard,
+		allowLegacyWildcard:     wildcard,
 		subscribedResourceNames: map[string]struct{}{},
 		returnedResources:       initialResourceVersions,
 	}
@@ -28,38 +39,118 @@ func NewSubscription(wildcard bool, initialResourceVersions map[string]string) S
 	return state
 }
 
+func NewSotwSubscription(subscribed []string) Subscription {
+	sub := newSubscription(len(subscribed) == 0, nil)
+	sub.SetResourceSubscription(subscribed)
+	return sub
+}
+
+// SetResourceSubscription updates the subscribed resources (including the wildcard state)
+// based on the full state of subscribed resources provided in the request
+// Used in sotw subscriptions
+// Behavior is based on
+// https://www.envoyproxy.io/docs/envoy/latest/api-docs/xds_protocol#how-the-client-specifies-what-resources-to-return
+func (s *Subscription) SetResourceSubscription(subscribed []string) {
+	if s.allowLegacyWildcard {
+		if len(subscribed) == 0 {
+			// We were wildcard based on legacy behavior and still don't request any resource
+			// The watch remains wildcard
+			return
+		}
+
+		// A resource was provided (might be an explicit wildcard)
+		// Documentation states that we should no longer allow to fallback to the previous case
+		// and no longer setting wildcard would no longer subscribe to anything
+		s.allowLegacyWildcard = false
+	}
+
+	subscribedResources := make(map[string]struct{}, len(subscribed))
+	explicitWildcardSet := false
+	for _, resource := range subscribed {
+		if resource == explicitWildcard {
+			explicitWildcardSet = true
+		} else {
+			subscribedResources[resource] = struct{}{}
+		}
+	}
+
+	// Explicit subscription to wildcard as we are not in legacy wildcard behavior
+	s.wildcard = explicitWildcardSet
+	s.subscribedResourceNames = subscribedResources
+}
+
+func NewDeltaSubscription(subscribed, unsubscribed []string, initialResourceVersions map[string]string) Subscription {
+	sub := newSubscription(len(subscribed) == 0, initialResourceVersions)
+	sub.UpdateResourceSubscriptions(subscribed, unsubscribed)
+	return sub
+}
+
+// UpdateResourceSubscriptions updates the subscribed resources (including the wildcard state)
+// based on newly subscribed or unsubscribed resources
+// Used in delta subscriptions
+func (s *Subscription) UpdateResourceSubscriptions(subscribed, unsubscribed []string) {
+	// Handles legacy wildcard behavior first to exit if we are still in this behavior
+	if s.allowLegacyWildcard {
+		// The protocol (as of v1.29.0) only references subscribed as triggering
+		// exiting legacy wildcard behavior, so we currently not check unsubscribed
+		if len(subscribed) == 0 {
+			// We were wildcard based on legacy behavior and still don't request any resource
+			// The watch remains wildcard
+			return
+		}
+
+		// A resource was provided (might be an explicit wildcard)
+		// Documentation states that we should no longer allow to fallback to the previous case
+		// and no longer setting wildcard would no longer subscribe to anything
+		// The watch does remain wildcard if not explicitly unsubscribed (from the example in
+		// https://www.envoyproxy.io/docs/envoy/v1.29.0/api-docs/xds_protocol#how-the-client-specifies-what-resources-to-return)
+		s.allowLegacyWildcard = false
+	}
+
+	// Handle subscriptions first
+	for _, resource := range subscribed {
+		if resource == explicitWildcard {
+			s.wildcard = true
+			continue
+		}
+		s.subscribedResourceNames[resource] = struct{}{}
+	}
+
+	// Then unsubscriptions
+	for _, resource := range unsubscribed {
+		if resource == explicitWildcard {
+			s.wildcard = false
+			continue
+		}
+		if _, ok := s.subscribedResourceNames[resource]; ok && s.wildcard {
+			// The XDS protocol states that:
+			// * if a watch is currently wildcard
+			// * a resource is explicitly unsubscribed by name
+			// Then the control-plane must return in the response whether the resource is removed (if no longer present for this node)
+			// or still existing. In the latter case the entire resource must be returned, same as if it had been created or updated
+			// To achieve that, we mark the resource as having been returned with an empty version. While creating the response, the cache will either:
+			// * detect the version change, and return the resource (as an update)
+			// * detect the resource deletion, and set it as removed in the response
+			s.returnedResources[resource] = ""
+		}
+		delete(s.subscribedResourceNames, resource)
+	}
+}
+
 // SubscribedResources returns the list of resources currently explicitly subscribed to
 // If the request is set to wildcard it may be empty
-// Can only be used for delta watches
-// TODO(valerian-roche): set those resources properly for sotw subscriptions
 func (s Subscription) SubscribedResources() map[string]struct{} {
 	return s.subscribedResourceNames
 }
 
-func (s *Subscription) SetSubscribedResources(resources map[string]struct{}) {
-	if resources != nil {
-		s.subscribedResourceNames = resources
-	} else {
-		s.subscribedResourceNames = make(map[string]struct{})
-	}
-}
-
 // IsWildcard returns whether or not the subscription currently has a wildcard watch
-// Can only be used for delta watches
-// TODO(valerian-roche): set those resources properly for sotw subscriptions
 func (s Subscription) IsWildcard() bool {
 	return s.wildcard
-}
-
-// SetWildcard sets whether the subscription is using a wildcard watch, whether legacy or not
-func (s *Subscription) SetWildcard(wildcard bool) {
-	s.wildcard = wildcard
 }
 
 // WatchesResources returns whether at least one of the resources provided is currently being watched by the subscription.
 // If the request is wildcard, it will always return true,
 // otherwise it will compare the provided resources to the list of resources currently subscribed
-// Can only be used for delta watches
 func (s Subscription) WatchesResources(resourceNames map[string]struct{}) bool {
 	if s.wildcard {
 		return true

--- a/pkg/server/stream/v3/subscription_test.go
+++ b/pkg/server/stream/v3/subscription_test.go
@@ -1,0 +1,159 @@
+package stream
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSotwSubscriptions(t *testing.T) {
+	t.Run("legacy mode properly handled", func(t *testing.T) {
+		sub := NewSotwSubscription([]string{})
+		assert.True(t, sub.IsWildcard())
+
+		// Requests always set empty in legacy mode
+		sub.SetResourceSubscription([]string{})
+		assert.True(t, sub.IsWildcard())
+		assert.Empty(t, sub.SubscribedResources())
+
+		// Requests always set empty in legacy mode
+		sub.SetResourceSubscription(nil)
+		assert.True(t, sub.IsWildcard())
+		assert.Empty(t, sub.SubscribedResources())
+
+		// Set any resource, no longer wildcard
+		sub.SetResourceSubscription([]string{"resource"})
+		assert.False(t, sub.IsWildcard())
+		assert.Equal(t, map[string]struct{}{"resource": {}}, sub.SubscribedResources())
+
+		// No longer watch any resource, should not come back to wildcard as no longer in legacy mode
+		// We end up with a watch to nothing
+		sub.SetResourceSubscription(nil)
+		assert.False(t, sub.IsWildcard())
+		assert.Empty(t, sub.SubscribedResources())
+	})
+
+	t.Run("new wildcard mode from start", func(t *testing.T) {
+		// A resource is provided so the subscription was created in wildcard
+		sub := NewSotwSubscription([]string{"*"})
+		assert.True(t, sub.IsWildcard())
+		assert.Empty(t, sub.SubscribedResources())
+
+		// Keep wildcard, no change
+		sub.SetResourceSubscription([]string{"*"})
+		assert.True(t, sub.IsWildcard())
+		assert.Empty(t, sub.SubscribedResources())
+
+		// Add resource to wildcard
+		sub.SetResourceSubscription([]string{"*", "resource"})
+		assert.True(t, sub.IsWildcard())
+		assert.Equal(t, map[string]struct{}{"resource": {}}, sub.SubscribedResources())
+
+		// Add/Remove resource to wildcard
+		sub.SetResourceSubscription([]string{"*", "otherresource"})
+		assert.True(t, sub.IsWildcard())
+		assert.Equal(t, map[string]struct{}{"otherresource": {}}, sub.SubscribedResources())
+
+		// Remove wildcard
+		sub.SetResourceSubscription([]string{"otherresource"})
+		assert.False(t, sub.IsWildcard())
+		assert.Equal(t, map[string]struct{}{"otherresource": {}}, sub.SubscribedResources())
+
+		// Remove last resource
+		sub.SetResourceSubscription([]string{})
+		assert.False(t, sub.IsWildcard())
+		assert.Empty(t, sub.SubscribedResources())
+
+		// Re-subscribe to wildcard
+		sub.SetResourceSubscription([]string{"*"})
+		assert.True(t, sub.IsWildcard())
+		assert.Empty(t, sub.SubscribedResources())
+	})
+}
+
+func TestDeltaSubscriptions(t *testing.T) {
+	t.Run("legacy mode properly handled", func(t *testing.T) {
+		sub := NewDeltaSubscription([]string{}, []string{}, map[string]string{"resource": "version"})
+		assert.True(t, sub.IsWildcard())
+		assert.Empty(t, sub.SubscribedResources())
+		assert.Equal(t, map[string]string{"resource": "version"}, sub.ReturnedResources())
+
+		// New request with no additional subscription
+		sub.UpdateResourceSubscriptions(nil, nil)
+		assert.True(t, sub.IsWildcard())
+		assert.Empty(t, sub.SubscribedResources())
+		assert.Equal(t, map[string]string{"resource": "version"}, sub.ReturnedResources())
+
+		// New request adding a resource
+		sub.UpdateResourceSubscriptions([]string{"resource"}, nil)
+		assert.True(t, sub.IsWildcard()) // Wildcard not unsubscribed
+		assert.Equal(t, map[string]struct{}{"resource": {}}, sub.SubscribedResources())
+		assert.Equal(t, map[string]string{"resource": "version"}, sub.ReturnedResources())
+
+		// Unsubscribe from "resource", still wildcard
+		sub.UpdateResourceSubscriptions(nil, []string{"resource"})
+		assert.True(t, sub.IsWildcard())
+		assert.Empty(t, sub.SubscribedResources())
+		// Version is set to "" to trigger an update or have the resource in the "removed" field
+		// when explicitly unsubscribing from wildcard, to align with
+		// https://www.envoyproxy.io/docs/envoy/v1.29.0/api-docs/xds_protocol#xds-protocol-unsubscribe
+		assert.Equal(t, map[string]string{"resource": ""}, sub.ReturnedResources())
+	})
+
+	t.Run("new wildcard mode", func(t *testing.T) {
+		// A resource is provided so the subscription was created in wildcard
+		sub := NewDeltaSubscription([]string{"*"}, []string{}, map[string]string{"resource": "version"})
+		assert.True(t, sub.IsWildcard())
+		assert.Empty(t, sub.SubscribedResources())
+
+		// New request with no additional subscription
+		sub.UpdateResourceSubscriptions(nil, nil)
+		assert.True(t, sub.IsWildcard())
+		assert.Empty(t, sub.SubscribedResources())
+		assert.Equal(t, map[string]string{"resource": "version"}, sub.ReturnedResources())
+
+		// Add resource to wildcard
+		sub.UpdateResourceSubscriptions([]string{"resource"}, []string{})
+		assert.True(t, sub.IsWildcard())
+		assert.Equal(t, map[string]struct{}{"resource": {}}, sub.SubscribedResources())
+		assert.Equal(t, map[string]string{"resource": "version"}, sub.ReturnedResources())
+
+		// Unsubscribe from resource while wildcard
+		sub.UpdateResourceSubscriptions([]string{"otherresource"}, []string{"resource"})
+		assert.True(t, sub.IsWildcard())
+		assert.Equal(t, map[string]struct{}{"otherresource": {}}, sub.SubscribedResources())
+		// Version is set to "" to trigger an update or have the resource in the "removed" field
+		// when explicitly unsubscribing from wildcard, to align with
+		// https://www.envoyproxy.io/docs/envoy/v1.29.0/api-docs/xds_protocol#xds-protocol-unsubscribe
+		assert.Equal(t, map[string]string{"resource": ""}, sub.ReturnedResources())
+
+		sub.SetReturnedResources(nil)
+
+		// Remove subscription to wildcard
+		sub.UpdateResourceSubscriptions([]string{"resource"}, []string{"*"})
+		assert.False(t, sub.IsWildcard())
+		assert.Equal(t, map[string]struct{}{"resource": {}, "otherresource": {}}, sub.SubscribedResources())
+		assert.Empty(t, sub.ReturnedResources())
+
+		// Remove all subscriptions
+		// Does not come back to wildcard
+		sub.UpdateResourceSubscriptions([]string{}, []string{"resource", "otherresource"})
+		assert.False(t, sub.IsWildcard())
+		assert.Empty(t, sub.SubscribedResources())
+
+		// Attempt to remove wildcard when not subscribed
+		sub.UpdateResourceSubscriptions([]string{"resource"}, []string{"*"})
+		assert.False(t, sub.IsWildcard())
+		assert.Equal(t, map[string]struct{}{"resource": {}}, sub.SubscribedResources())
+
+		// Resubscribe to wildcard
+		sub.UpdateResourceSubscriptions([]string{"*"}, nil)
+		assert.True(t, sub.IsWildcard())
+		assert.Equal(t, map[string]struct{}{"resource": {}}, sub.SubscribedResources())
+
+		// Attempt to remove not-subscribed resource. Should just be ignored
+		sub.UpdateResourceSubscriptions([]string{}, []string{"otherresource"})
+		assert.True(t, sub.IsWildcard())
+		assert.Equal(t, map[string]struct{}{"resource": {}}, sub.SubscribedResources())
+	})
+}

--- a/pkg/server/v3/server_test.go
+++ b/pkg/server/v3/server_test.go
@@ -32,6 +32,7 @@ import (
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
 	"github.com/envoyproxy/go-control-plane/pkg/cache/v3"
+	"github.com/envoyproxy/go-control-plane/pkg/log"
 	rsrc "github.com/envoyproxy/go-control-plane/pkg/resource/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/server/sotw/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/server/v3"
@@ -50,10 +51,11 @@ type mockConfigWatcher struct {
 }
 
 func (config *mockConfigWatcher) CreateWatch(req *discovery.DiscoveryRequest, _ cache.Subscription, out chan cache.Response) (func(), error) {
-	config.counts[req.GetTypeUrl()] = config.counts[req.GetTypeUrl()] + 1
-	if len(config.responses[req.GetTypeUrl()]) > 0 {
-		out <- config.responses[req.GetTypeUrl()][0]
-		config.responses[req.GetTypeUrl()] = config.responses[req.GetTypeUrl()][1:]
+	typ := req.GetTypeUrl()
+	config.counts[typ]++
+	if len(config.responses[typ]) > 0 {
+		out <- config.responses[typ][0]
+		config.responses[typ] = config.responses[typ][1:]
 	} else {
 		config.watches++
 		return func() {
@@ -64,9 +66,10 @@ func (config *mockConfigWatcher) CreateWatch(req *discovery.DiscoveryRequest, _ 
 }
 
 func (config *mockConfigWatcher) Fetch(_ context.Context, req *discovery.DiscoveryRequest) (cache.Response, error) {
-	if len(config.responses[req.GetTypeUrl()]) > 0 {
-		out := config.responses[req.GetTypeUrl()][0]
-		config.responses[req.GetTypeUrl()] = config.responses[req.GetTypeUrl()][1:]
+	typ := req.GetTypeUrl()
+	if len(config.responses[typ]) > 0 {
+		out := config.responses[typ][0]
+		config.responses[typ] = config.responses[typ][1:]
 		return out, nil
 	}
 	return nil, errors.New("missing")
@@ -258,7 +261,7 @@ func TestServerShutdown(t *testing.T) {
 			config.responses = makeResponses()
 			shutdown := make(chan bool)
 			ctx, cancel := context.WithCancel(context.Background())
-			s := server.NewServer(ctx, config, server.CallbackFuncs{})
+			s := server.NewServer(ctx, config, server.CallbackFuncs{}, sotw.WithLogger(log.NewTestLogger(t)))
 
 			// make a request
 			resp := makeMockStream(t)
@@ -312,7 +315,7 @@ func TestResponseHandlers(t *testing.T) {
 
 			config := makeMockConfigWatcher()
 			config.responses = makeResponses()
-			s := server.NewServer(ctx, config, server.CallbackFuncs{})
+			s := server.NewServer(ctx, config, server.CallbackFuncs{}, sotw.WithLogger(log.NewTestLogger(t)))
 
 			// make a request
 			resp := makeMockStream(t)
@@ -388,7 +391,7 @@ func TestFetch(t *testing.T) {
 		},
 	}
 
-	s := server.NewServer(context.Background(), config, cb)
+	s := server.NewServer(context.Background(), config, cb, sotw.WithLogger(log.NewTestLogger(t)))
 	out, err := s.FetchEndpoints(context.Background(), &discovery.DiscoveryRequest{Node: node})
 	assert.NotNil(t, out)
 	require.NoError(t, err)
@@ -483,7 +486,7 @@ func TestSendError(t *testing.T) {
 		t.Run(typ, func(t *testing.T) {
 			config := makeMockConfigWatcher()
 			config.responses = makeResponses()
-			s := server.NewServer(context.Background(), config, server.CallbackFuncs{})
+			s := server.NewServer(context.Background(), config, server.CallbackFuncs{}, sotw.WithLogger(log.NewTestLogger(t)))
 
 			// make a request
 			resp := makeMockStream(t)
@@ -507,7 +510,7 @@ func TestStaleNonce(t *testing.T) {
 		t.Run(typ, func(t *testing.T) {
 			config := makeMockConfigWatcher()
 			config.responses = makeResponses()
-			s := server.NewServer(context.Background(), config, server.CallbackFuncs{})
+			s := server.NewServer(context.Background(), config, server.CallbackFuncs{}, sotw.WithLogger(log.NewTestLogger(t)))
 
 			resp := makeMockStream(t)
 			resp.recv <- &discovery.DiscoveryRequest{
@@ -519,11 +522,11 @@ func TestStaleNonce(t *testing.T) {
 				err := s.StreamAggregatedResources(resp)
 				require.NoError(t, err)
 				// should be two watches called
-				assert.True(t, reflect.DeepEqual(map[string]int{typ: 2}, config.counts))
+				assert.True(t, reflect.DeepEqual(map[string]int{typ: 2}, config.counts), config.counts)
 				close(stop)
 			}()
 			select {
-			case <-resp.sent:
+			case res := <-resp.sent:
 				// stale request
 				resp.recv <- &discovery.DiscoveryRequest{
 					Node:          node,
@@ -532,10 +535,10 @@ func TestStaleNonce(t *testing.T) {
 				}
 				// fresh request
 				resp.recv <- &discovery.DiscoveryRequest{
-					VersionInfo:   "1",
+					VersionInfo:   res.VersionInfo,
 					Node:          node,
 					TypeUrl:       typ,
-					ResponseNonce: "1",
+					ResponseNonce: res.Nonce,
 				}
 				close(resp.recv)
 			case <-time.After(1 * time.Second):
@@ -582,7 +585,7 @@ func TestAggregatedHandlers(t *testing.T) {
 
 	// We create the server with the optional ordered ADS flag so we guarantee resource
 	// ordering over the stream.
-	s := server.NewServer(context.Background(), config, server.CallbackFuncs{}, sotw.WithOrderedADS())
+	s := server.NewServer(context.Background(), config, server.CallbackFuncs{}, sotw.WithOrderedADS(), sotw.WithLogger(log.NewTestLogger(t)))
 	go func() {
 		err := s.StreamAggregatedResources(resp)
 		require.NoError(t, err)
@@ -617,7 +620,7 @@ func TestAggregatedHandlers(t *testing.T) {
 
 func TestAggregateRequestType(t *testing.T) {
 	config := makeMockConfigWatcher()
-	s := server.NewServer(context.Background(), config, server.CallbackFuncs{})
+	s := server.NewServer(context.Background(), config, server.CallbackFuncs{}, sotw.WithLogger(log.NewTestLogger(t)))
 	resp := makeMockStream(t)
 	resp.recv <- &discovery.DiscoveryRequest{Node: node}
 	err := s.StreamAggregatedResources(resp)
@@ -634,7 +637,7 @@ func TestCancellations(t *testing.T) {
 		}
 	}
 	close(resp.recv)
-	s := server.NewServer(context.Background(), config, server.CallbackFuncs{})
+	s := server.NewServer(context.Background(), config, server.CallbackFuncs{}, sotw.WithLogger(log.NewTestLogger(t)))
 	err := s.StreamAggregatedResources(resp)
 	require.NoError(t, err)
 	assert.Equal(t, 0, config.watches)
@@ -652,7 +655,7 @@ func TestOpaqueRequestsChannelMuxing(t *testing.T) {
 		}
 	}
 	close(resp.recv)
-	s := server.NewServer(context.Background(), config, server.CallbackFuncs{})
+	s := server.NewServer(context.Background(), config, server.CallbackFuncs{}, sotw.WithLogger(log.NewTestLogger(t)))
 	err := s.StreamAggregatedResources(resp)
 	require.NoError(t, err)
 	assert.Equal(t, 0, config.watches)


### PR DESCRIPTION
In the previous interface using `stream.StreamState` to provide the subscription view to the `Cache` interface, the different entries were set or not set based on whether it was `sotw` or `delta` requests. Some were also per type while others were across types
Now that the `Subscription` has been standardized to be uniform for `sotw` and `delta`, as well as always for the given request type, this PR ensures all the fields are properly populated in all cases
A follow-up PR will rely on those informations to address current issues in the cache implementations related to resource tracking