### PR TITLE
[Sotw][Linear cache] Ensure watches are properly considering subscription changes to not miss new resources

### DIFF
--- a/pkg/cache/v3/delta_test.go
+++ b/pkg/cache/v3/delta_test.go
@@ -16,6 +16,7 @@ import (
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
 	"github.com/envoyproxy/go-control-plane/pkg/cache/v3"
+	"github.com/envoyproxy/go-control-plane/pkg/log"
 	rsrc "github.com/envoyproxy/go-control-plane/pkg/resource/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/server/stream/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/test/resource/v3"
@@ -30,7 +31,7 @@ func assertResourceMapEqual(t *testing.T, want, got map[string]types.Resource) {
 }
 
 func TestSnapshotCacheDeltaWatch(t *testing.T) {
-	c := cache.NewSnapshotCache(false, group{}, logger{t: t})
+	c := cache.NewSnapshotCache(false, group{}, log.NewTestLogger(t))
 	watches := make(map[string]chan cache.DeltaResponse)
 	subscriptions := make(map[string]stream.Subscription)
 
@@ -118,7 +119,7 @@ func TestSnapshotCacheDeltaWatch(t *testing.T) {
 }
 
 func TestDeltaRemoveResources(t *testing.T) {
-	c := cache.NewSnapshotCache(false, group{}, logger{t: t})
+	c := cache.NewSnapshotCache(false, group{}, log.NewTestLogger(t))
 	watches := make(map[string]chan cache.DeltaResponse)
 	subscriptions := make(map[string]*stream.Subscription)
 
@@ -198,7 +199,7 @@ func TestDeltaRemoveResources(t *testing.T) {
 }
 
 func TestConcurrentSetDeltaWatch(t *testing.T) {
-	c := cache.NewSnapshotCache(false, group{}, logger{t: t})
+	c := cache.NewSnapshotCache(false, group{}, log.NewTestLogger(t))
 	for i := 0; i < 50; i++ {
 		version := fmt.Sprintf("v%d", i)
 		func(i int) {
@@ -235,7 +236,7 @@ func TestConcurrentSetDeltaWatch(t *testing.T) {
 type testKey struct{}
 
 func TestSnapshotDeltaCacheWatchTimeout(t *testing.T) {
-	c := cache.NewSnapshotCache(true, group{}, logger{t: t})
+	c := cache.NewSnapshotCache(true, group{}, log.NewTestLogger(t))
 
 	// Create a non-buffered channel that will block sends.
 	watchCh := make(chan cache.DeltaResponse)
@@ -280,7 +281,7 @@ func TestSnapshotDeltaCacheWatchTimeout(t *testing.T) {
 }
 
 func TestSnapshotCacheDeltaWatchCancel(t *testing.T) {
-	c := cache.NewSnapshotCache(true, group{}, logger{t: t})
+	c := cache.NewSnapshotCache(true, group{}, log.NewTestLogger(t))
 	for _, typ := range testTypes {
 		responses := make(chan cache.DeltaResponse, 1)
 		cancel, err := c.CreateDeltaWatch(&discovery.DeltaDiscoveryRequest{

--- a/pkg/cache/v3/linear.go
+++ b/pkg/cache/v3/linear.go
@@ -27,8 +27,6 @@ import (
 	"github.com/envoyproxy/go-control-plane/pkg/log"
 )
 
-type watches = map[ResponseWatch]struct{}
-
 // LinearCache supports collections of opaque resources. This cache has a
 // single collection indexed by resource names and manages resource versions
 // internally. It implements the cache interface for a single type URL and
@@ -41,9 +39,11 @@ type LinearCache struct {
 	resources map[string]types.Resource
 	// Watches open by clients, indexed by resource name. Whenever resources
 	// are changed, the watch is triggered.
-	watches map[string]watches
+	watches map[string]map[int64]ResponseWatch
 	// Set of watches for all resources in the collection
-	watchAll watches
+	watchAll map[int64]ResponseWatch
+	// Continuously incremented counter used to index sotw watches.
+	sotwWatchCount int64
 	// Set of delta watches. A delta watch always contain the list of subscribed resources
 	// together with its current version
 	// version and versionPrefix fields are ignored for delta watches, because we always generate the resource version.
@@ -58,7 +58,7 @@ type LinearCache struct {
 	// Version prefix to be sent to the clients
 	versionPrefix string
 	// Versions for each resource by name.
-	versionVector map[string]uint64
+	versionVector map[string]string
 
 	log log.Logger
 
@@ -83,9 +83,6 @@ func WithVersionPrefix(prefix string) LinearCacheOption {
 func WithInitialResources(resources map[string]types.Resource) LinearCacheOption {
 	return func(cache *LinearCache) {
 		cache.resources = resources
-		for name := range resources {
-			cache.versionVector[name] = 0
-		}
 	}
 }
 
@@ -100,74 +97,170 @@ func NewLinearCache(typeURL string, opts ...LinearCacheOption) *LinearCache {
 	out := &LinearCache{
 		typeURL:       typeURL,
 		resources:     make(map[string]types.Resource),
-		watches:       make(map[string]watches),
-		watchAll:      make(watches),
+		watches:       make(map[string]map[int64]ResponseWatch),
+		watchAll:      make(map[int64]ResponseWatch),
 		deltaWatches:  make(map[int64]DeltaResponseWatch),
 		versionMap:    nil,
 		version:       0,
-		versionVector: make(map[string]uint64),
+		versionVector: make(map[string]string),
 		log:           log.NewDefaultLogger(),
 	}
 	for _, opt := range opts {
 		opt(out)
 	}
+	for name := range out.resources {
+		out.versionVector[name] = out.getVersion()
+	}
 	return out
 }
 
-func (cache *LinearCache) respond(watch ResponseWatch, staleResources []string) {
-	var resources []types.ResourceWithTTL
-	// TODO: optimize the resources slice creations across different clients
-	if len(staleResources) == 0 {
-		// Wildcard case, we return all resources in the cache
-		resources = make([]types.ResourceWithTTL, 0, len(cache.resources))
-		for _, resource := range cache.resources {
-			resources = append(resources, types.ResourceWithTTL{Resource: resource})
+func (cache *LinearCache) computeSotwResponse(watch ResponseWatch, ignoreReturnedResources bool) *RawResponse {
+	var changedResources []string
+	var removedResources []string
+
+	knownVersions := watch.subscription.ReturnedResources()
+	if ignoreReturnedResources {
+		// The response will include all resources, with no regards of resources potentially already returned.
+		knownVersions = make(map[string]string)
+	}
+
+	if watch.subscription.IsWildcard() {
+		for resourceName, version := range cache.versionVector {
+			knownVersion, ok := knownVersions[resourceName]
+			if !ok {
+				// This resource is not yet known by the client (added or the client has a stale view)
+				changedResources = append(changedResources, resourceName)
+			} else if knownVersion != version {
+				// Outdated version
+				changedResources = append(changedResources, resourceName)
+			}
 		}
-	} else if ResourceRequiresFullStateInSotw(cache.typeURL) {
-		// Non-wildcard request for a type requiring full state response
-		// We need to return all requested resources, if existing, for this type
-		requestedResources := watch.Request.GetResourceNames()
-		resources = make([]types.ResourceWithTTL, 0, len(requestedResources))
-		for _, resource := range requestedResources {
-			resource := cache.resources[resource]
-			if resource != nil {
-				resources = append(resources, types.ResourceWithTTL{Resource: resource})
+
+		// Negative check to retrieve resources that would have been removed
+		for resourceName := range knownVersions {
+			if _, ok := cache.versionVector[resourceName]; !ok {
+				// Known resource no longer exists.
+				removedResources = append(removedResources, resourceName)
 			}
 		}
 	} else {
-		// Non-wildcard request for other types. Only return stale resources
-		resources = make([]types.ResourceWithTTL, 0, len(staleResources))
-		for _, name := range staleResources {
-			resource := cache.resources[name]
-			if resource != nil {
-				resources = append(resources, types.ResourceWithTTL{Resource: resource})
+		for resourceName := range watch.subscription.SubscribedResources() {
+			version, exists := cache.versionVector[resourceName]
+			knownVersion, known := knownVersions[resourceName]
+			if !exists {
+				if known {
+					// This resource was removed and is no longer known. If the type requires full state
+					// we need to return to make it aware
+					removedResources = append(removedResources, resourceName)
+				}
+				continue
+			}
+
+			if !known {
+				// This resource is not yet known by the client (added or the client has a stale view)
+				changedResources = append(changedResources, resourceName)
+			} else if knownVersion != version {
+				// Outdated version
+				changedResources = append(changedResources, resourceName)
+			}
+		}
+
+		for resourceName := range knownVersions {
+			// If the subscription no longer watches a resource, we mark it as unknown on the client side to ensure it will
+			// be resent to the client if subscribing again later on.
+			if _, ok := watch.subscription.SubscribedResources()[resourceName]; !ok {
+				delete(knownVersions, resourceName)
 			}
 		}
 	}
-	watch.Response <- &RawResponse{
-		Request:   watch.Request,
-		Resources: resources,
-		Version:   cache.getVersion(),
-		Ctx:       context.Background(),
+
+	if len(changedResources) == 0 && len(removedResources) == 0 && !ignoreReturnedResources {
+		// Nothing changed.
+		return nil
+	}
+
+	returnedVersions := make(map[string]string, len(watch.subscription.ReturnedResources()))
+	// Clone the current returned versions. The cache should not alter the subscription
+	for resourceName, version := range watch.subscription.ReturnedResources() {
+		returnedVersions[resourceName] = version
+	}
+
+	cacheVersion := cache.getVersion()
+	var resources []types.ResourceWithTTL
+
+	switch {
+	// Depending on the type, the response will only include changed resources or all of them
+	case !ResourceRequiresFullStateInSotw(cache.typeURL):
+		// changedResources is already filtered based on the subscription
+		resources = make([]types.ResourceWithTTL, 0, len(changedResources))
+		for _, resourceName := range changedResources {
+			resources = append(resources, types.ResourceWithTTL{Resource: cache.resources[resourceName]})
+			returnedVersions[resourceName] = cache.versionVector[resourceName]
+		}
+	case watch.subscription.IsWildcard():
+		// Include all resources for the type.
+		resources = make([]types.ResourceWithTTL, 0, len(cache.resources))
+		for resourceName, resource := range cache.resources {
+			resources = append(resources, types.ResourceWithTTL{Resource: resource})
+			returnedVersions[resourceName] = cache.versionVector[resourceName]
+		}
+	default:
+		requestedResources := watch.subscription.SubscribedResources()
+		// The linear cache could be very large (e.g. containing all potential CLAs)
+		// Therefore drive on the subscription requested resources.
+		resources = make([]types.ResourceWithTTL, 0, len(requestedResources))
+		for resourceName := range requestedResources {
+			resource, ok := cache.resources[resourceName]
+			if !ok {
+				continue
+			}
+			resources = append(resources, types.ResourceWithTTL{Resource: resource})
+			returnedVersions[resourceName] = cache.versionVector[resourceName]
+		}
+	}
+
+	// Cleanup resources no longer existing in the cache.
+	// In sotw we cannot return those, but this ensures we detect unsubscription then resubscription
+	for _, resourceName := range removedResources {
+		delete(returnedVersions, resourceName)
+	}
+
+	return &RawResponse{
+		Request:           watch.Request,
+		Resources:         resources,
+		ReturnedResources: returnedVersions,
+		Version:           cacheVersion,
+		Ctx:               context.Background(),
 	}
 }
 
 func (cache *LinearCache) notifyAll(modified map[string]struct{}) {
-	// de-duplicate watches that need to be responded
-	notifyList := make(map[ResponseWatch][]string)
+	// Gather the list of non-wildcard watches impacted by the modified resources.
+	watches := make(map[int64]ResponseWatch)
 	for name := range modified {
-		for watch := range cache.watches[name] {
-			notifyList[watch] = append(notifyList[watch], name)
+		for watchId, watch := range cache.watches[name] {
+			watches[watchId] = watch
 		}
 	}
-	for watch, stale := range notifyList {
-		cache.removeWatch(watch)
-		cache.respond(watch, stale)
+	for watchId, watch := range watches {
+		response := cache.computeSotwResponse(watch, false)
+		if response != nil {
+			watch.Response <- response
+			cache.removeWatch(watchId, watch.subscription)
+		} else {
+			cache.log.Warnf("[Linear cache] Watch %d detected as triggered did not get notified", watchId)
+		}
 	}
-	for watch := range cache.watchAll {
-		cache.respond(watch, nil)
+
+	for watchId, watch := range cache.watchAll {
+		response := cache.computeSotwResponse(watch, false)
+		if response != nil {
+			watch.Response <- response
+			delete(cache.watchAll, watchId)
+		} else {
+			cache.log.Warnf("[Linear cache] Watch %d detected as triggered did not get notified", watchId)
+		}
 	}
-	cache.watchAll = make(watches)
 
 	// Building the version map has a very high cost when using SetResources to do full updates.
 	// As it is only used with delta watches, it is only maintained when applicable.
@@ -218,7 +311,7 @@ func (cache *LinearCache) UpdateResource(name string, res types.Resource) error 
 	defer cache.mu.Unlock()
 
 	cache.version++
-	cache.versionVector[name] = cache.version
+	cache.versionVector[name] = cache.getVersion()
 	cache.resources[name] = res
 
 	// TODO: batch watch closures to prevent rapid updates
@@ -249,10 +342,11 @@ func (cache *LinearCache) UpdateResources(toUpdate map[string]types.Resource, to
 	defer cache.mu.Unlock()
 
 	cache.version++
+	cacheVersion := cache.getVersion()
 
 	modified := make(map[string]struct{}, len(toUpdate)+len(toDelete))
 	for name, resource := range toUpdate {
-		cache.versionVector[name] = cache.version
+		cache.versionVector[name] = cacheVersion
 		cache.resources[name] = resource
 		modified[name] = struct{}{}
 	}
@@ -275,6 +369,7 @@ func (cache *LinearCache) SetResources(resources map[string]types.Resource) {
 	defer cache.mu.Unlock()
 
 	cache.version++
+	cacheVersion := cache.getVersion()
 
 	modified := map[string]struct{}{}
 	// Collect deleted resource names.
@@ -291,7 +386,7 @@ func (cache *LinearCache) SetResources(resources map[string]types.Resource) {
 	// We assume all resources passed to SetResources are changed.
 	// Otherwise we would have to do proto.Equal on resources which is pretty expensive operation
 	for name := range resources {
-		cache.versionVector[name] = cache.version
+		cache.versionVector[name] = cacheVersion
 		modified[name] = struct{}{}
 	}
 
@@ -312,90 +407,82 @@ func (cache *LinearCache) GetResources() map[string]types.Resource {
 	return resources
 }
 
-func (cache *LinearCache) CreateWatch(request *Request, _ Subscription, value chan Response) (func(), error) {
+func (cache *LinearCache) CreateWatch(request *Request, sub Subscription, value chan Response) (func(), error) {
 	if request.GetTypeUrl() != cache.typeURL {
 		return nil, fmt.Errorf("request type %s does not match cache type %s", request.GetTypeUrl(), cache.typeURL)
 	}
-	// If the version is not up to date, check whether any requested resource has
-	// been updated between the last version and the current version. This avoids the problem
-	// of sending empty updates whenever an irrelevant resource changes.
-	stale := false
-	staleResources := []string{} // empty means all
 
-	// strip version prefix if it is present
-	var lastVersion uint64
-	var err error
-	if strings.HasPrefix(request.GetVersionInfo(), cache.versionPrefix) {
-		lastVersion, err = strconv.ParseUint(request.GetVersionInfo()[len(cache.versionPrefix):], 0, 64)
-	} else {
-		err = errors.New("mis-matched version prefix")
+	// If the request does not include a version the client considers it has no current state.
+	// In this case we will always reply to allow proper initialization of dependencies in the client.
+	ignoreCurrentSubscriptionResources := request.GetVersionInfo() == ""
+	if !strings.HasPrefix(request.GetVersionInfo(), cache.versionPrefix) {
+		// If the version of the request does not match the cache prefix, we will send a response in all cases to match the legacy behavior.
+		ignoreCurrentSubscriptionResources = true
+		cache.log.Debugf("[linear cache] received watch with version %s not matching the cache prefix %s. Will return all known resources", request.GetVersionInfo(), cache.versionPrefix)
 	}
 
-	watch := ResponseWatch{Request: request, Response: value}
+	// A major difference between delta and sotw is the ability to not resend everything when connecting to a new control-plane
+	// In delta the request provides the version of the resources it does know, even if the request is wildcard or does request more resources
+	// In sotw the request only provides the global version of the control-plane, and there is no way for the control-plane to know if resources have
+	// been added since in the requested resources. In the context of generalized wildcard, even wildcard could be new, and taking the assumption
+	// that wildcard implies that the client already knows all resources at the given version is no longer true.
+	// We could optimize the reconnection case here if:
+	//  - we take the assumption that clients will not start requesting wildcard while providing a version. We could then ignore requests providing the resources.
+	//  - we use the version as some form of hash of resources known, and we can then consider it as a way to correctly verify whether all resources are unchanged.
+	// For now it is not done as:
+	//  - for the first case, while the protocol documentation does not explicitly mention the case, it does not mark it impossible and explicitly references unsubscribing from wildcard.
+	//  - for the second one we could likely do it with little difficulty if need be, but if users rely on the current monotonic version it could impact their callbacks implementations.
+	watch := ResponseWatch{Request: request, Response: value, subscription: sub}
 
 	cache.mu.Lock()
 	defer cache.mu.Unlock()
 
-	switch {
-	case err != nil:
-		stale = true
-		staleResources = request.GetResourceNames()
-		cache.log.Debugf("Watch is stale as version failed to parse %s", err.Error())
-	case len(request.GetResourceNames()) == 0:
-		stale = (lastVersion != cache.version)
-		if stale {
-			cache.log.Debugf("Watch is stale as cache version %d differs for wildcard watch %d", cache.version, lastVersion)
-		}
-	default:
-		for _, name := range request.GetResourceNames() {
-			// When a resource is removed, its version defaults 0 and it is not considered stale.
-			if lastVersion < cache.versionVector[name] {
-				stale = true
-				staleResources = append(staleResources, name)
-			}
-		}
-		if stale {
-			cache.log.Debugf("Watch is stale with stale resources %v", staleResources)
-		}
+	response := cache.computeSotwResponse(watch, ignoreCurrentSubscriptionResources)
+	if response != nil {
+		cache.log.Debugf("replying to the watch with resources %v (subscription values %v, known %v)", response.GetReturnedResources(), sub.SubscribedResources(), sub.ReturnedResources())
+		watch.Response <- response
+		return func() {}, nil
 	}
-	if stale {
-		cache.respond(watch, staleResources)
-		return nil, nil
-	}
+
+	watchId := cache.nextSotwWatchID()
 	// Create open watches since versions are up to date.
-	if len(request.GetResourceNames()) == 0 {
-		cache.log.Infof("[linear cache] open watch for %s all resources, system version %q", cache.typeURL, cache.getVersion())
-		cache.watchAll[watch] = struct{}{}
+	if sub.IsWildcard() {
+		cache.log.Infof("[linear cache] open watch %d for %s all resources, system version %q", watchId, cache.typeURL, cache.getVersion())
+		cache.watchAll[watchId] = watch
 		return func() {
 			cache.mu.Lock()
 			defer cache.mu.Unlock()
-			delete(cache.watchAll, watch)
+			delete(cache.watchAll, watchId)
 		}, nil
 	}
 
-	cache.log.Infof("[linear cache] open watch for %s resources %v, system version %q", cache.typeURL, request.ResourceNames, cache.getVersion())
-	for _, name := range request.GetResourceNames() {
+	cache.log.Infof("[linear cache] open watch %d for %s resources %v, system version %q", watchId, cache.typeURL, sub.SubscribedResources(), cache.getVersion())
+	for name := range sub.SubscribedResources() {
 		set, exists := cache.watches[name]
 		if !exists {
-			set = make(watches)
+			set = make(map[int64]ResponseWatch)
 			cache.watches[name] = set
 		}
-		set[watch] = struct{}{}
+		set[watchId] = watch
 	}
 	return func() {
 		cache.mu.Lock()
 		defer cache.mu.Unlock()
-		cache.removeWatch(watch)
+		cache.removeWatch(watchId, watch.subscription)
 	}, nil
 }
 
+func (cache *LinearCache) nextSotwWatchID() int64 {
+	return atomic.AddInt64(&cache.sotwWatchCount, 1)
+}
+
 // Must be called under lock
-func (cache *LinearCache) removeWatch(watch ResponseWatch) {
+func (cache *LinearCache) removeWatch(watchId int64, sub Subscription) {
 	// Make sure we clean the watch for ALL resources it might be associated with,
 	// as the channel will no longer be listened to
-	for _, resource := range watch.Request.ResourceNames {
+	for resource := range sub.SubscribedResources() {
 		resourceWatches := cache.watches[resource]
-		delete(resourceWatches, watch)
+		delete(resourceWatches, watchId)
 		if len(resourceWatches) == 0 {
 			delete(cache.watches, resource)
 		}

--- a/pkg/cache/v3/linear.go
+++ b/pkg/cache/v3/linear.go
@@ -489,10 +489,11 @@ func (cache *LinearCache) CreateWatch(request *Request, sub Subscription, value 
 }
 
 func (cache *LinearCache) nextSotwWatchID() int64 {
-	if atomic.LoadInt64(&cache.sotwWatchCount)+1 < 0 {
+	next := atomic.AddInt64(&cache.sotwWatchCount, 1)
+	if next < 0 {
 		panic("watch id count overflow")
 	}
-	return atomic.AddInt64(&cache.sotwWatchCount, 1)
+	return next
 }
 
 // Must be called under lock

--- a/pkg/cache/v3/linear_test.go
+++ b/pkg/cache/v3/linear_test.go
@@ -491,8 +491,6 @@ func TestLinearDeletion(t *testing.T) {
 		require.NoError(t, c.DeleteResource("a"))
 		// For non full-state type, we don't return on deletion
 		mustBlock(t, w)
-		// We currently do not clean watches for resources on deletion.
-		// checkWatchCount(t, c, "a", 0)
 
 		cancel()
 		checkWatchCount(t, c, "a", 0)
@@ -1181,6 +1179,7 @@ func TestLinearSotwNonWildcard(t *testing.T) {
 		return &discovery.DiscoveryRequest{
 			ResourceNames: res,
 			TypeUrl:       resourceType,
+			VersionInfo:   version,
 		}
 	}
 	updateReqResources := func(index int, res []string) {
@@ -1267,7 +1266,7 @@ func TestLinearSotwNonWildcard(t *testing.T) {
 		checkPendingWatch(4)
 
 		// Update the cache
-		cache.UpdateResources(map[string]types.Resource{
+		_ = cache.UpdateResources(map[string]types.Resource{
 			"b": buildEndpoint("b"),
 			"d": buildEndpoint("d"),
 		}, []string{"a"})
@@ -1292,8 +1291,8 @@ func TestLinearSotwNonWildcard(t *testing.T) {
 		createWatch(4)
 		checkPendingWatch(4)
 
-		// Add a new resource not request in all subscriptions
-		cache.UpdateResource("e", buildEndpoint("e"))
+		// Add a new resource not requested in all subscriptions
+		_ = cache.UpdateResource("e", buildEndpoint("e"))
 		validateResponse(1, []string{"e"})
 		createWatch(1)
 		checkPendingWatch(1)
@@ -1323,14 +1322,14 @@ func TestLinearSotwNonWildcard(t *testing.T) {
 
 		// Do an update removing a resource only
 		// This type is not full update, and therefore does not return
-		cache.UpdateResources(nil, []string{"c"})
+		_ = cache.UpdateResources(nil, []string{"c"})
 		checkPendingWatch(1)
 		checkPendingWatch(2)
 		checkPendingWatch(3)
 		checkPendingWatch(4)
 
 		// Do an update in the cache to confirm all is well
-		cache.UpdateResources(map[string]types.Resource{
+		_ = cache.UpdateResources(map[string]types.Resource{
 			"a": buildEndpoint("a"),
 			"b": buildEndpoint("b"),
 		}, nil)
@@ -1393,7 +1392,7 @@ func TestLinearSotwNonWildcard(t *testing.T) {
 		checkPendingWatch(4)
 
 		// Update the cache
-		cache.UpdateResources(map[string]types.Resource{
+		_ = cache.UpdateResources(map[string]types.Resource{
 			"b": buildCluster("b"),
 			"d": buildCluster("d"),
 		}, []string{"a"})
@@ -1419,7 +1418,7 @@ func TestLinearSotwNonWildcard(t *testing.T) {
 		checkPendingWatch(4)
 
 		// Add a new resource not request in all subscriptions
-		cache.UpdateResource("e", buildCluster("e"))
+		_ = cache.UpdateResource("e", buildCluster("e"))
 		validateResponse(1, []string{"b", "c", "d", "e"})
 		createWatch(1)
 		checkPendingWatch(1)
@@ -1449,7 +1448,7 @@ func TestLinearSotwNonWildcard(t *testing.T) {
 
 		// Do an update removing a resource only
 		// This type is not full update, and therefore does not return
-		cache.UpdateResources(nil, []string{"c"})
+		_ = cache.UpdateResources(nil, []string{"c"})
 		validateResponse(1, []string{"b", "d", "e"})
 		checkPendingWatch(2)
 		validateResponse(3, []string{"b", "d", "e"})
@@ -1463,7 +1462,7 @@ func TestLinearSotwNonWildcard(t *testing.T) {
 		checkPendingWatch(4)
 
 		// Do an update in the cache to confirm all is well
-		cache.UpdateResources(map[string]types.Resource{
+		_ = cache.UpdateResources(map[string]types.Resource{
 			"a": buildCluster("a"),
 			"b": buildCluster("b"),
 		}, nil)

--- a/pkg/cache/v3/simple.go
+++ b/pkg/cache/v3/simple.go
@@ -404,7 +404,7 @@ func (cache *snapshotCache) CreateWatch(request *Request, sub Subscription, valu
 
 	createWatch := func(watch ResponseWatch) func() {
 		watchID := cache.nextWatchID()
-		cache.log.Debugf("open watch %d for %s%v from nodeID %q, version %q", watchID, request.GetTypeUrl(), sub.SubscribedResources(), nodeID, request.GetVersionInfo())
+		cache.log.Debugf("open watch %d for %s %v from nodeID %q, version %q", watchID, request.GetTypeUrl(), sub.SubscribedResources(), nodeID, request.GetVersionInfo())
 		info.mu.Lock()
 		info.watches[watchID] = watch
 		info.mu.Unlock()

--- a/pkg/cache/v3/simple.go
+++ b/pkg/cache/v3/simple.go
@@ -207,7 +207,7 @@ func (cache *snapshotCache) sendHeartbeats(ctx context.Context, node string) {
 				continue
 			}
 			cache.log.Debugf("respond open watch %d%v with heartbeat for version %q", id, watch.Request.GetResourceNames(), version)
-			err := cache.respond(ctx, watch.Request, watch.Response, resourcesWithTTL, version, true)
+			err := cache.respond(ctx, watch, resourcesWithTTL, version, true)
 			if err != nil {
 				cache.log.Errorf("received error when attempting to respond to watches: %v", err)
 			}
@@ -252,7 +252,7 @@ func (cache *snapshotCache) respondSOTWWatches(ctx context.Context, info *status
 		if version != watch.Request.GetVersionInfo() {
 			cache.log.Debugf("respond open watch %d %s%v with new version %q", id, watch.Request.GetTypeUrl(), watch.Request.GetResourceNames(), version)
 			resources := snapshot.GetResourcesAndTTL(watch.Request.GetTypeUrl())
-			err := cache.respond(ctx, watch.Request, watch.Response, resources, version, false)
+			err := cache.respond(ctx, watch, resources, version, false)
 			if err != nil {
 				return err
 			}
@@ -402,54 +402,58 @@ func (cache *snapshotCache) CreateWatch(request *Request, sub Subscription, valu
 	info.lastWatchRequestTime = time.Now()
 	info.mu.Unlock()
 
-	var version string
-	snapshot, exists := cache.snapshots[nodeID]
-	if exists {
-		version = snapshot.GetVersion(request.GetTypeUrl())
+	createWatch := func(watch ResponseWatch) func() {
+		watchID := cache.nextWatchID()
+		cache.log.Debugf("open watch %d for %s%v from nodeID %q, version %q", watchID, request.GetTypeUrl(), sub.SubscribedResources(), nodeID, request.GetVersionInfo())
+		info.mu.Lock()
+		info.watches[watchID] = watch
+		info.mu.Unlock()
+		return cache.cancelWatch(nodeID, watchID)
 	}
 
-	if exists {
+	watch := ResponseWatch{Request: request, Response: value, subscription: sub}
+
+	snapshot, exists := cache.snapshots[nodeID]
+	if !exists {
+		return createWatch(watch), nil
+	}
+
+	version := snapshot.GetVersion(request.GetTypeUrl())
+	resources := snapshot.GetResourcesAndTTL(request.GetTypeUrl())
+
+	if request.GetVersionInfo() == version {
+		// Retrieve whether there are resources in the cache requested and currently unknown to the client.
 		knownResourceNames := sub.ReturnedResources()
-		diff := []string{}
-		for _, r := range request.GetResourceNames() {
-			if _, ok := knownResourceNames[r]; !ok {
-				diff = append(diff, r)
+		diff := false
+		if !sub.IsWildcard() {
+			// Check if a resource requested is currently not returned,
+			// for instance if it is newly subscribed
+			for r := range sub.SubscribedResources() {
+				if _, ok := knownResourceNames[r]; !ok {
+					diff = true
+					break
+				}
 			}
-		}
-
-		cache.log.Debugf("nodeID %q requested %s%v and known %v. Diff %v", nodeID,
-			request.GetTypeUrl(), request.GetResourceNames(), knownResourceNames, diff)
-
-		if len(diff) > 0 {
-			resources := snapshot.GetResourcesAndTTL(request.GetTypeUrl())
-			for _, name := range diff {
-				if _, exists := resources[name]; exists {
-					if err := cache.respond(context.Background(), request, value, resources, version, false); err != nil {
-						cache.log.Errorf("failed to send a response for %s%v to nodeID %q: %s", request.GetTypeUrl(),
-							request.GetResourceNames(), nodeID, err)
-						return nil, fmt.Errorf("failed to send the response: %w", err)
-					}
-					return func() {}, nil
+		} else {
+			// Check if a resource present in the snapshot is currently not returned,
+			// for instance if the subscription is newly wildcard.
+			for r := range snapshot.GetResources(request.GetTypeUrl()) {
+				if _, ok := knownResourceNames[r]; !ok {
+					diff = true
+					break
 				}
 			}
 		}
+		// The version has not changed, and the client already has all requested resources.
+		if !diff {
+			return createWatch(watch), nil
+		}
 	}
 
-	// if the requested version is up-to-date or missing a response, leave an open watch
-	if !exists || request.GetVersionInfo() == version {
-		watchID := cache.nextWatchID()
-		cache.log.Debugf("open watch %d for %s%v from nodeID %q, version %q", watchID, request.GetTypeUrl(), request.GetResourceNames(), nodeID, request.GetVersionInfo())
-		info.mu.Lock()
-		info.watches[watchID] = ResponseWatch{Request: request, Response: value}
-		info.mu.Unlock()
-		return cache.cancelWatch(nodeID, watchID), nil
-	}
-
-	// otherwise, the watch may be responded immediately
-	resources := snapshot.GetResourcesAndTTL(request.GetTypeUrl())
-	if err := cache.respond(context.Background(), request, value, resources, version, false); err != nil {
+	// The version is different, or the client is subscribed to resources not yet returned to it.
+	if err := cache.respond(context.Background(), watch, resources, version, false); err != nil {
 		cache.log.Errorf("failed to send a response for %s%v to nodeID %q: %s", request.GetTypeUrl(),
-			request.GetResourceNames(), nodeID, err)
+			sub.SubscribedResources(), nodeID, err)
 		return nil, fmt.Errorf("failed to send the response: %w", err)
 	}
 
@@ -476,7 +480,8 @@ func (cache *snapshotCache) cancelWatch(nodeID string, watchID int64) func() {
 
 // Respond to a watch with the snapshot value. The value channel should have capacity not to block.
 // TODO(kuat) do not respond always, see issue https://github.com/envoyproxy/go-control-plane/issues/46
-func (cache *snapshotCache) respond(ctx context.Context, request *Request, value chan Response, resources map[string]types.ResourceWithTTL, version string, heartbeat bool) error {
+func (cache *snapshotCache) respond(ctx context.Context, watch ResponseWatch, resources map[string]types.ResourceWithTTL, version string, heartbeat bool) error {
+	request := watch.Request
 	// for ADS, the request names must match the snapshot names
 	// if they do not, then the watch is never responded, and it is expected that envoy makes another request
 	if len(request.GetResourceNames()) != 0 && cache.ads {
@@ -489,7 +494,7 @@ func (cache *snapshotCache) respond(ctx context.Context, request *Request, value
 	cache.log.Debugf("respond %s%v version %q with version %q", request.GetTypeUrl(), request.GetResourceNames(), request.GetVersionInfo(), version)
 
 	select {
-	case value <- createResponse(ctx, request, resources, version, heartbeat):
+	case watch.Response <- createResponse(ctx, request, resources, version, heartbeat):
 		return nil
 	case <-ctx.Done():
 		return context.Canceled
@@ -498,6 +503,7 @@ func (cache *snapshotCache) respond(ctx context.Context, request *Request, value
 
 func createResponse(ctx context.Context, request *Request, resources map[string]types.ResourceWithTTL, version string, heartbeat bool) Response {
 	filtered := make([]types.ResourceWithTTL, 0, len(resources))
+	returnedResources := make(map[string]string, len(resources))
 
 	// Reply only with the requested resources. Envoy may ask each resource
 	// individually in a separate stream. It is ok to reply with the same version
@@ -507,20 +513,23 @@ func createResponse(ctx context.Context, request *Request, resources map[string]
 		for name, resource := range resources {
 			if set[name] {
 				filtered = append(filtered, resource)
+				returnedResources[name] = version
 			}
 		}
 	} else {
-		for _, resource := range resources {
+		for name, resource := range resources {
 			filtered = append(filtered, resource)
+			returnedResources[name] = version
 		}
 	}
 
 	return &RawResponse{
-		Request:   request,
-		Version:   version,
-		Resources: filtered,
-		Heartbeat: heartbeat,
-		Ctx:       ctx,
+		Request:           request,
+		Version:           version,
+		Resources:         filtered,
+		ReturnedResources: returnedResources,
+		Heartbeat:         heartbeat,
+		Ctx:               ctx,
 	}
 }
 

--- a/pkg/cache/v3/simple.go
+++ b/pkg/cache/v3/simple.go
@@ -206,7 +206,7 @@ func (cache *snapshotCache) sendHeartbeats(ctx context.Context, node string) {
 			if len(resourcesWithTTL) == 0 {
 				continue
 			}
-			cache.log.Debugf("respond open watch %d%v with heartbeat for version %q", id, watch.Request.GetResourceNames(), version)
+			cache.log.Debugf("respond open watch %d %v with heartbeat for version %q", id, watch.Request.GetResourceNames(), version)
 			err := cache.respond(ctx, watch, resourcesWithTTL, version, true)
 			if err != nil {
 				cache.log.Errorf("received error when attempting to respond to watches: %v", err)
@@ -250,7 +250,7 @@ func (cache *snapshotCache) respondSOTWWatches(ctx context.Context, info *status
 	respond := func(watch ResponseWatch, id int64) error {
 		version := snapshot.GetVersion(watch.Request.GetTypeUrl())
 		if version != watch.Request.GetVersionInfo() {
-			cache.log.Debugf("respond open watch %d %s%v with new version %q", id, watch.Request.GetTypeUrl(), watch.Request.GetResourceNames(), version)
+			cache.log.Debugf("respond open watch %d %s %v with new version %q", id, watch.Request.GetTypeUrl(), watch.Request.GetResourceNames(), version)
 			resources := snapshot.GetResourcesAndTTL(watch.Request.GetTypeUrl())
 			err := cache.respond(ctx, watch, resources, version, false)
 			if err != nil {
@@ -486,7 +486,7 @@ func (cache *snapshotCache) respond(ctx context.Context, watch ResponseWatch, re
 	// if they do not, then the watch is never responded, and it is expected that envoy makes another request
 	if len(request.GetResourceNames()) != 0 && cache.ads {
 		if err := superset(nameSet(request.GetResourceNames()), resources); err != nil {
-			cache.log.Warnf("ADS mode: not responding to request %s%v: %v", request.GetTypeUrl(), request.GetResourceNames(), err)
+			cache.log.Warnf("ADS mode: not responding to request %s %v: %v", request.GetTypeUrl(), request.GetResourceNames(), err)
 			return nil
 		}
 	}

--- a/pkg/cache/v3/status.go
+++ b/pkg/cache/v3/status.go
@@ -90,6 +90,9 @@ type ResponseWatch struct {
 
 	// Response is the channel to push responses to.
 	Response chan Response
+
+	// Subscription stores the current client subscription state.
+	subscription Subscription
 }
 
 // DeltaResponseWatch is a watch record keeping both the delta request and an open channel for the delta response.

--- a/pkg/server/sotw/v3/server.go
+++ b/pkg/server/sotw/v3/server.go
@@ -121,17 +121,7 @@ func (s *streamWrapper) send(resp cache.Response) error {
 	}
 
 	// Track in the type subcription the nonce and objects returned to the client.
-	version, err := resp.GetVersion()
-	if err != nil {
-		return err
-	}
-	// ToDo(valerian-roche): properly return the resources actually sent to the client
-	// Currently we set all resources requested, which is non-descriptive when using wildcard.
-	resources := make(map[string]string, len(resp.GetRequest().GetResourceNames()))
-	for _, r := range resp.GetRequest().GetResourceNames() {
-		resources[r] = version
-	}
-	w.sub.SetReturnedResources(resources)
+	w.sub.SetReturnedResources(resp.GetReturnedResources())
 	w.nonce = out.Nonce
 
 	// Register with the callbacks provided that we are sending the response.


### PR DESCRIPTION
In the current sotw implementation of linear cache, the interpretation of the version provided in the request creates multiple issues in the case of non-wildcard watches (and even potentially for wildcard):
 - if wildcard, and version prefix is not used, a request to a new cache can have a matching version but actually be outdated, as the version only depends on insertion order and not resource content
 - if not using wildcard, multiple issues are present:
   - the version may be up-to-date, but a new resource added to the subscription. Currently this resource is not returned as the version is still up-to-date for all resources in the subscription
   - when using full state resources, resource deletion must be notified, but deletion will be ignored as the resource is not in the cache so won't be detected
   - the current use of monotonic version creates constraint in the semantic meaning of versions, while not handling the issue of deletion. We remove this meaning to enable reusing the version for other usecases in the future

This PR also brings the implementation of sotw far closer to delta. Future work will attempt to merge both cases to provide a more uniform behavior, simplifying maintenance and testing for new features.

This PR also provides one major change of behavior: currently, if a new subscription comes in and the version does match in wildcard mode (or is higher than the version of each independent resource in non-wildcard), the watch is not replied to. While this avoids some traffic, it is technically not valid due to the cases mentioned above. This change of behavior remains in line with the protocol specification (not returning if nothing has changed on connection is an optional optimization)