### PR TITLE
[Linear cache] rework watches and storage in the cache to make code more common between delta and sotw

### DIFF
--- a/pkg/cache/v3/cache.go
+++ b/pkg/cache/v3/cache.go
@@ -56,12 +56,6 @@ type Subscription interface {
 	// This considers subtleties related to the current migration of wildcard definitions within the protocol.
 	// More details on the behavior of wildcard are present at https://www.envoyproxy.io/docs/envoy/latest/api-docs/xds_protocol#how-the-client-specifies-what-resources-to-return
 	IsWildcard() bool
-
-	// WatchesResources returns whether at least one of the resources provided is currently being watched by the subscription.
-	// It is currently only applicable to delta-xds.
-	// If the request is wildcard, it will always return true,
-	// otherwise it will compare the provided resources to the list of resources currently subscribed
-	WatchesResources(resourceNames map[string]struct{}) bool
 }
 
 // ConfigWatcher requests watches for configuration resources by a node, last

--- a/pkg/cache/v3/delta.go
+++ b/pkg/cache/v3/delta.go
@@ -22,12 +22,11 @@ import (
 
 // groups together resource-related arguments for the createDeltaResponse function
 type resourceContainer struct {
-	resourceMap   map[string]types.Resource
-	versionMap    map[string]string
-	systemVersion string
+	resourceMap map[string]types.Resource
+	versionMap  map[string]string
 }
 
-func createDeltaResponse(ctx context.Context, req *DeltaRequest, sub Subscription, resources resourceContainer) *RawDeltaResponse {
+func createDeltaResponse(ctx context.Context, req *DeltaRequest, sub Subscription, resources resourceContainer, cacheVersion string) *RawDeltaResponse {
 	// variables to build our response with
 	var nextVersionMap map[string]string
 	var filtered []types.Resource
@@ -81,7 +80,7 @@ func createDeltaResponse(ctx context.Context, req *DeltaRequest, sub Subscriptio
 		Resources:         filtered,
 		RemovedResources:  toRemove,
 		NextVersionMap:    nextVersionMap,
-		SystemVersionInfo: resources.systemVersion,
+		SystemVersionInfo: cacheVersion,
 		Ctx:               ctx,
 	}
 }

--- a/pkg/cache/v3/linear.go
+++ b/pkg/cache/v3/linear.go
@@ -28,15 +28,37 @@ import (
 
 // cachedResource is used to track resources added by the user in the cache.
 // It contains the resource itself and its associated version (currently in two different modes).
-// TODO(valerian-roche): store serialized resource if already marshaled to compute the version.
 type cachedResource struct {
 	types.Resource
 
 	// cacheVersion is the version of the cache at the time of last update, used in sotw.
 	cacheVersion string
-	// resourceVersion is the version of the resource itself (built through stable marshaling).
-	// It is only set if computeResourceVersion is set to true on the cache.
-	resourceVersion string
+	// stableVersion is the version of the resource itself (a hash of its content after deterministic marshaling).
+	// It is lazy initialized and should be accessed through getStableVersion.
+	stableVersion string
+}
+
+func (c *cachedResource) getStableVersion() (string, error) {
+	if c.stableVersion != "" {
+		return c.stableVersion, nil
+	}
+
+	// TODO(valerian-roche): store serialized resource as part of the cachedResource
+	// to reuse it when marshaling the responses instead of remarshaling and recomputing the version then.
+	marshaledResource, err := MarshalResource(c.Resource)
+	if err != nil {
+		return "", err
+	}
+	c.stableVersion = HashResource(marshaledResource)
+	return c.stableVersion, nil
+}
+
+func (c *cachedResource) getVersion(useStableVersion bool) (string, error) {
+	if !useStableVersion {
+		return c.cacheVersion, nil
+	}
+
+	return c.getStableVersion()
 }
 
 type watches struct {
@@ -69,7 +91,7 @@ type LinearCache struct {
 	typeURL string
 
 	// resources contains all resources currently set in the cache and associated versions.
-	resources map[string]cachedResource
+	resources map[string]*cachedResource
 
 	// resourceWatches keeps track of watches currently opened specifically tracking a resource.
 	// It does not contain wildcard watches.
@@ -85,9 +107,6 @@ type LinearCache struct {
 	// versionPrefix is used to modify the version returned to clients, and can be used to uniquely identify
 	// cache instances and avoid issues of version reuse.
 	versionPrefix string
-
-	// areStableResourceVersionsComputed indicates whether the cache is currently computing and storing stable resource versions.
-	areStableResourceVersionsComputed bool
 
 	log log.Logger
 
@@ -112,7 +131,7 @@ func WithVersionPrefix(prefix string) LinearCacheOption {
 func WithInitialResources(resources map[string]types.Resource) LinearCacheOption {
 	return func(cache *LinearCache) {
 		for name, resource := range resources {
-			cache.resources[name] = cachedResource{
+			cache.resources[name] = &cachedResource{
 				Resource: resource,
 			}
 		}
@@ -125,21 +144,11 @@ func WithLogger(log log.Logger) LinearCacheOption {
 	}
 }
 
-// WithComputeStableVersions ensures the cache tracks the resources stable versions from the beginning,
-// avoiding the first watch stalling until the computation has been done on all resources.
-// If the cache is expected to handle delta watches, this option is fully beneficial.
-// If the cache is expected to only handle sotw watches, it is currently not needed and will increase CPU usage.
-func WithComputeStableVersions() LinearCacheOption {
-	return func(cache *LinearCache) {
-		cache.areStableResourceVersionsComputed = true
-	}
-}
-
 // NewLinearCache creates a new cache. See the comments on the struct definition.
 func NewLinearCache(typeURL string, opts ...LinearCacheOption) *LinearCache {
 	out := &LinearCache{
 		typeURL:         typeURL,
-		resources:       make(map[string]cachedResource),
+		resources:       make(map[string]*cachedResource),
 		resourceWatches: make(map[string]watches),
 		wildcardWatches: newWatches(),
 		version:         0,
@@ -151,32 +160,28 @@ func NewLinearCache(typeURL string, opts ...LinearCacheOption) *LinearCache {
 	}
 	for name, resource := range out.resources {
 		resource.cacheVersion = out.getVersion()
-		if out.areStableResourceVersionsComputed {
-			version, err := computeResourceStableVersion(resource.Resource)
-			if err != nil {
-				out.log.Errorf("failed to build stable versions for resource %s: %s", name, err)
-			} else {
-				resource.resourceVersion = version
-			}
-		}
 		out.resources[name] = resource
 	}
 	return out
 }
 
-func (cache *LinearCache) computeResourceChange(sub Subscription, ignoreReturnedResources, useStableVersion bool) (updated, removed []string) {
+// computeResourceChange compares the subscription known resources and the cache current state to compute the list of resources
+// which have changed and should be notified to the user.
+//
+// The alwaysConsiderAllResources argument removes the consideration of the subscription known resources (e.g. if the version did not match),
+// and return all known subscribed resources.
+//
+// The useStableVersion argument defines what version type to use for resources:
+//   - if set to false versions are based on when resources were updated in the cache.
+//   - if set to true versions are a stable property of the resource, with no regard to when it was added to the cache.
+func (cache *LinearCache) computeResourceChange(sub Subscription, alwaysConsiderAllResources, useStableVersion bool) (updated, removed []string, err error) {
 	var changedResources []string
 	var removedResources []string
 
 	knownVersions := sub.ReturnedResources()
-	if ignoreReturnedResources {
+	if alwaysConsiderAllResources {
 		// The response will include all resources, with no regards of resources potentially already returned.
 		knownVersions = make(map[string]string)
-	}
-
-	getVersion := func(c cachedResource) string { return c.cacheVersion }
-	if useStableVersion {
-		getVersion = func(c cachedResource) string { return c.resourceVersion }
 	}
 
 	if sub.IsWildcard() {
@@ -185,9 +190,15 @@ func (cache *LinearCache) computeResourceChange(sub Subscription, ignoreReturned
 			if !ok {
 				// This resource is not yet known by the client (new resource added in the cache or newly subscribed).
 				changedResources = append(changedResources, resourceName)
-			} else if knownVersion != getVersion(resource) {
-				// The client knows an outdated version.
-				changedResources = append(changedResources, resourceName)
+			} else {
+				resourceVersion, err := resource.getVersion(useStableVersion)
+				if err != nil {
+					return nil, nil, fmt.Errorf("failed to compute version of %s: %w", resourceName, err)
+				}
+				if knownVersion != resourceVersion {
+					// The client knows an outdated version.
+					changedResources = append(changedResources, resourceName)
+				}
 			}
 		}
 
@@ -215,9 +226,15 @@ func (cache *LinearCache) computeResourceChange(sub Subscription, ignoreReturned
 			if !known {
 				// This resource is not yet known by the client (new resource added in the cache or newly subscribed).
 				changedResources = append(changedResources, resourceName)
-			} else if knownVersion != getVersion(res) {
-				// The client knows an outdated version.
-				changedResources = append(changedResources, resourceName)
+			} else {
+				resourceVersion, err := res.getVersion(useStableVersion)
+				if err != nil {
+					return nil, nil, fmt.Errorf("failed to compute version of %s: %w", resourceName, err)
+				}
+				if knownVersion != resourceVersion {
+					// The client knows an outdated version.
+					changedResources = append(changedResources, resourceName)
+				}
 			}
 		}
 
@@ -230,14 +247,18 @@ func (cache *LinearCache) computeResourceChange(sub Subscription, ignoreReturned
 		}
 	}
 
-	return changedResources, removedResources
+	return changedResources, removedResources, nil
 }
 
-func (cache *LinearCache) computeSotwResponse(watch ResponseWatch, ignoreReturnedResources bool) *RawResponse {
-	changedResources, removedResources := cache.computeResourceChange(watch.subscription, ignoreReturnedResources, false)
-	if len(changedResources) == 0 && len(removedResources) == 0 && !ignoreReturnedResources {
+func (cache *LinearCache) computeSotwResponse(watch ResponseWatch, alwaysConsiderAllResources bool) (*RawResponse, error) {
+	changedResources, removedResources, err := cache.computeResourceChange(watch.subscription, alwaysConsiderAllResources, false)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(changedResources) == 0 && len(removedResources) == 0 && !alwaysConsiderAllResources {
 		// Nothing changed.
-		return nil
+		return nil, nil
 	}
 
 	returnedVersions := make(map[string]string, len(watch.subscription.ReturnedResources()))
@@ -250,12 +271,10 @@ func (cache *LinearCache) computeSotwResponse(watch ResponseWatch, ignoreReturne
 	var resources []types.ResourceWithTTL
 
 	switch {
-	// Depending on the type, the response will only include changed resources or all of them
+	// For lds and cds, answers will always include all matching resources, with no regard to which resource was changed or removed.
+	// For other types, the response only includes updated resources (sotw cannot notify for deletion).
 	case !ResourceRequiresFullStateInSotw(cache.typeURL):
 		// changedResources is already filtered based on the subscription.
-		// TODO(valerian-roche): if the only change is a removal in the subscription,
-		// or a watched resource getting deleted, this might send an empty reply.
-		// While this does not violate the protocol, we might want to avoid it.
 		resources = make([]types.ResourceWithTTL, 0, len(changedResources))
 		for _, resourceName := range changedResources {
 			cachedResource := cache.resources[resourceName]
@@ -293,11 +312,11 @@ func (cache *LinearCache) computeSotwResponse(watch ResponseWatch, ignoreReturne
 		delete(returnedVersions, resourceName)
 	}
 
-	if !ignoreReturnedResources && !ResourceRequiresFullStateInSotw(cache.typeURL) && len(resources) == 0 {
+	if !alwaysConsiderAllResources && !ResourceRequiresFullStateInSotw(cache.typeURL) && len(resources) == 0 {
 		// If the request is not the initial one, and the type does not require full updates,
-		// do not return if noting is to be set.
+		// do not return if nothing is to be set.
 		// For full-state resources an empty response does have a semantic meaning.
-		return nil
+		return nil, nil
 	}
 
 	return &RawResponse{
@@ -306,14 +325,18 @@ func (cache *LinearCache) computeSotwResponse(watch ResponseWatch, ignoreReturne
 		ReturnedResources: returnedVersions,
 		Version:           cacheVersion,
 		Ctx:               context.Background(),
-	}
+	}, nil
 }
 
-func (cache *LinearCache) computeDeltaResponse(watch DeltaResponseWatch) *RawDeltaResponse {
-	changedResources, removedResources := cache.computeResourceChange(watch.subscription, false, true)
+func (cache *LinearCache) computeDeltaResponse(watch DeltaResponseWatch) (*RawDeltaResponse, error) {
+	changedResources, removedResources, err := cache.computeResourceChange(watch.subscription, false, true)
+	if err != nil {
+		return nil, err
+	}
+
 	if len(changedResources) == 0 && len(removedResources) == 0 {
 		// Nothing changed.
-		return nil
+		return nil, nil
 	}
 
 	returnedVersions := make(map[string]string, len(watch.subscription.ReturnedResources()))
@@ -327,7 +350,11 @@ func (cache *LinearCache) computeDeltaResponse(watch DeltaResponseWatch) *RawDel
 	for _, resourceName := range changedResources {
 		resource := cache.resources[resourceName]
 		resources = append(resources, resource.Resource)
-		returnedVersions[resourceName] = resource.resourceVersion
+		version, err := resource.getStableVersion()
+		if err != nil {
+			return nil, fmt.Errorf("failed to compute stable version of %s: %w", resourceName, err)
+		}
+		returnedVersions[resourceName] = version
 	}
 	// Cleanup resources no longer existing in the cache or no longer subscribed.
 	for _, resourceName := range removedResources {
@@ -341,10 +368,10 @@ func (cache *LinearCache) computeDeltaResponse(watch DeltaResponseWatch) *RawDel
 		NextVersionMap:    returnedVersions,
 		SystemVersionInfo: cacheVersion,
 		Ctx:               context.Background(),
-	}
+	}, nil
 }
 
-func (cache *LinearCache) notifyAll(modified []string) {
+func (cache *LinearCache) notifyAll(modified []string) error {
 	// Gather the list of watches impacted by the modified resources.
 	sotwWatches := make(map[uint64]ResponseWatch)
 	deltaWatches := make(map[uint64]DeltaResponseWatch)
@@ -359,7 +386,11 @@ func (cache *LinearCache) notifyAll(modified []string) {
 
 	// sotw watches
 	for watchID, watch := range sotwWatches {
-		response := cache.computeSotwResponse(watch, false)
+		response, err := cache.computeSotwResponse(watch, false)
+		if err != nil {
+			return err
+		}
+
 		if response != nil {
 			watch.Response <- response
 			cache.removeWatch(watchID, watch.subscription)
@@ -369,7 +400,11 @@ func (cache *LinearCache) notifyAll(modified []string) {
 	}
 
 	for watchID, watch := range cache.wildcardWatches.sotw {
-		response := cache.computeSotwResponse(watch, false)
+		response, err := cache.computeSotwResponse(watch, false)
+		if err != nil {
+			return err
+		}
+
 		if response != nil {
 			watch.Response <- response
 			delete(cache.wildcardWatches.sotw, watchID)
@@ -380,7 +415,11 @@ func (cache *LinearCache) notifyAll(modified []string) {
 
 	// delta watches
 	for watchID, watch := range deltaWatches {
-		response := cache.computeDeltaResponse(watch)
+		response, err := cache.computeDeltaResponse(watch)
+		if err != nil {
+			return err
+		}
+
 		if response != nil {
 			watch.Response <- response
 			cache.removeDeltaWatch(watchID, watch.subscription)
@@ -390,7 +429,11 @@ func (cache *LinearCache) notifyAll(modified []string) {
 	}
 
 	for watchID, watch := range cache.wildcardWatches.delta {
-		response := cache.computeDeltaResponse(watch)
+		response, err := cache.computeDeltaResponse(watch)
+		if err != nil {
+			return err
+		}
+
 		if response != nil {
 			watch.Response <- response
 			delete(cache.wildcardWatches.delta, watchID)
@@ -398,32 +441,24 @@ func (cache *LinearCache) notifyAll(modified []string) {
 			cache.log.Warnf("[Linear cache] Wildcard delta watch %d detected as triggered but no change was found", watchID)
 		}
 	}
+
+	return nil
 }
 
 func computeResourceStableVersion(res types.Resource) (string, error) {
-	// hash our version in here and build the version map
+	// TODO(valerian-roche): store serialized resource as part of the cachedResource
+	// to reuse it when marshaling the responses instead of remarshaling and recomputing the version then.
 	marshaledResource, err := MarshalResource(res)
 	if err != nil {
 		return "", err
 	}
-	v := HashResource(marshaledResource)
-	if v == "" {
-		return "", errors.New("failed to build resource version")
-	}
-	return v, nil
+	return HashResource(marshaledResource), nil
 }
 
 func (cache *LinearCache) addResourceToCache(name string, res types.Resource) error {
-	update := cachedResource{
+	update := &cachedResource{
 		Resource:     res,
 		cacheVersion: cache.getVersion(),
-	}
-	if cache.areStableResourceVersionsComputed {
-		version, err := computeResourceStableVersion(res)
-		if err != nil {
-			return err
-		}
-		update.resourceVersion = version
 	}
 	cache.resources[name] = update
 	return nil
@@ -442,9 +477,7 @@ func (cache *LinearCache) UpdateResource(name string, res types.Resource) error 
 		return err
 	}
 
-	cache.notifyAll([]string{name})
-
-	return nil
+	return cache.notifyAll([]string{name})
 }
 
 // DeleteResource removes a resource in the collection.
@@ -455,8 +488,7 @@ func (cache *LinearCache) DeleteResource(name string) error {
 	cache.version++
 	delete(cache.resources, name)
 
-	cache.notifyAll([]string{name})
-	return nil
+	return cache.notifyAll([]string{name})
 }
 
 // UpdateResources updates/deletes a list of resources in the cache.
@@ -479,14 +511,11 @@ func (cache *LinearCache) UpdateResources(toUpdate map[string]types.Resource, to
 		modified = append(modified, name)
 	}
 
-	cache.notifyAll(modified)
-
-	return nil
+	return cache.notifyAll(modified)
 }
 
 // SetResources replaces current resources with a new set of resources.
-// This function is useful for wildcard xDS subscriptions.
-// This way watches that are subscribed to all resources are triggered only once regardless of how many resources are changed.
+// If only some resources are to be updated, UpdateResources is more efficient.
 func (cache *LinearCache) SetResources(resources map[string]types.Resource) {
 	cache.mu.Lock()
 	defer cache.mu.Unlock()
@@ -512,7 +541,9 @@ func (cache *LinearCache) SetResources(resources map[string]types.Resource) {
 		modified = append(modified, name)
 	}
 
-	cache.notifyAll(modified)
+	if err := cache.notifyAll(modified); err != nil {
+		cache.log.Errorf("Failed to notify watches: %s", err.Error())
+	}
 }
 
 // GetResources returns current resources stored in the cache
@@ -563,7 +594,11 @@ func (cache *LinearCache) CreateWatch(request *Request, sub Subscription, value 
 	cache.mu.Lock()
 	defer cache.mu.Unlock()
 
-	response := cache.computeSotwResponse(watch, ignoreCurrentSubscriptionResources)
+	response, err := cache.computeSotwResponse(watch, ignoreCurrentSubscriptionResources)
+	if err != nil {
+		return nil, fmt.Errorf("failed to compute the watch respnse: %w", err)
+	}
+
 	if response != nil {
 		cache.log.Debugf("[linear cache] replying to the watch with resources %v (subscription values %v, known %v)", response.GetReturnedResources(), sub.SubscribedResources(), sub.ReturnedResources())
 		watch.Response <- response
@@ -621,24 +656,11 @@ func (cache *LinearCache) CreateDeltaWatch(request *DeltaRequest, sub Subscripti
 	cache.mu.Lock()
 	defer cache.mu.Unlock()
 
-	if !cache.areStableResourceVersionsComputed {
-		// If we had no previously open delta watches, we need to build the version map for the first time.
-		// The version map will not be destroyed when the last delta watch is removed.
-		// This avoids constantly rebuilding when only a few delta watches are open.
-		cache.areStableResourceVersionsComputed = true
-		cache.log.Infof("[linear cache] activating stable resource version computation for %s", cache.typeURL)
-
-		for name, cachedResource := range cache.resources {
-			version, err := computeResourceStableVersion(cachedResource.Resource)
-			if err != nil {
-				return func() {}, fmt.Errorf("failed to build stable versions for resource %s: %w", name, err)
-			}
-			cachedResource.resourceVersion = version
-			cache.resources[name] = cachedResource
-		}
+	response, err := cache.computeDeltaResponse(watch)
+	if err != nil {
+		return nil, fmt.Errorf("failed to compute the watch respnse: %w", err)
 	}
 
-	response := cache.computeDeltaResponse(watch)
 	if response != nil {
 		cache.log.Debugf("[linear cache] replying to the delta watch (subscription values %v, known %v)", sub.SubscribedResources(), sub.ReturnedResources())
 		watch.Response <- response
@@ -702,7 +724,7 @@ func (cache *LinearCache) Fetch(context.Context, *Request) (Response, error) {
 	return nil, errors.New("not implemented")
 }
 
-// Number of resources currently on the cache.
+// NumResources returns the number of resources currently in the cache.
 // As GetResources is building a clone it is expensive to get metrics otherwise.
 func (cache *LinearCache) NumResources() int {
 	cache.mu.RLock()
@@ -710,14 +732,14 @@ func (cache *LinearCache) NumResources() int {
 	return len(cache.resources)
 }
 
-// NumDeltaWatches returns the number of active sotw watches for a resource name.
+// NumWatches returns the number of active sotw watches for a resource name.
 func (cache *LinearCache) NumWatches(name string) int {
 	cache.mu.RLock()
 	defer cache.mu.RUnlock()
 	return len(cache.resourceWatches[name].sotw) + len(cache.wildcardWatches.sotw)
 }
 
-// NumDeltaWatches returns the number of active delta watches for a resource name.
+// NumDeltaWatchesForResource returns the number of active delta watches for a resource name.
 func (cache *LinearCache) NumDeltaWatchesForResource(name string) int {
 	cache.mu.RLock()
 	defer cache.mu.RUnlock()

--- a/pkg/cache/v3/linear_test.go
+++ b/pkg/cache/v3/linear_test.go
@@ -184,7 +184,7 @@ func verifyDeltaResponse(t *testing.T, ch <-chan DeltaResponse, resources []reso
 	var r DeltaResponse
 	select {
 	case r = <-ch:
-	case <-time.After(5 * time.Second):
+	case <-time.After(1 * time.Second):
 		t.Error("timeout waiting for delta response")
 		return
 	}
@@ -205,19 +205,16 @@ func checkDeltaWatchCount(t *testing.T, c *LinearCache, count int) {
 	}
 }
 
-func checkVersionMapNotSet(t *testing.T, c *LinearCache) {
+func checkStableVersionsAreNotComputed(t *testing.T, c *LinearCache) {
 	t.Helper()
-	if c.versionMap != nil {
-		t.Errorf("version map is set on the cache with %d elements", len(c.versionMap))
-	}
+	assert.False(t, c.areStableResourceVersionsComputed, "stable version computation is set on the cache")
 }
 
-func checkVersionMapSet(t *testing.T, c *LinearCache) {
+func checkStableVersionsAreComputed(t *testing.T, c *LinearCache) {
 	t.Helper()
-	if c.versionMap == nil {
-		t.Errorf("version map is not set on the cache")
-	} else if len(c.versionMap) != len(c.resources) {
-		t.Errorf("version map has the wrong number of elements: %d instead of %d expected", len(c.versionMap), len(c.resources))
+	assert.True(t, c.areStableResourceVersionsComputed, "stable version computation is not set on the cache")
+	for name, r := range c.resources {
+		assert.NotEmpty(t, r.resourceVersion, "stable version not set on resource %s", name)
 	}
 }
 
@@ -294,7 +291,7 @@ func TestLinearInitialResources(t *testing.T) {
 	_, err = c.CreateWatch(req, sub, w)
 	require.NoError(t, err)
 	verifyResponse(t, w, "0", 2)
-	checkVersionMapNotSet(t, c)
+	checkStableVersionsAreNotComputed(t, c)
 }
 
 func TestLinearCornerCases(t *testing.T) {
@@ -321,7 +318,7 @@ func TestLinearBasic(t *testing.T) {
 	_, err := c.CreateWatch(req1, sub1, w1)
 	require.NoError(t, err)
 	mustBlock(t, w1)
-	checkVersionMapNotSet(t, c)
+	checkStableVersionsAreNotComputed(t, c)
 
 	w2 := make(chan Response, 1)
 	req2 := &Request{TypeUrl: testType, VersionInfo: "0"}
@@ -369,7 +366,7 @@ func TestLinearBasic(t *testing.T) {
 	require.NoError(t, err)
 	verifyResponse(t, w2, "3", 2)
 	// Ensure the version map was not created as we only ever used stow watches
-	checkVersionMapNotSet(t, c)
+	checkStableVersionsAreNotComputed(t, c)
 }
 
 func TestLinearSetResources(t *testing.T) {
@@ -478,7 +475,7 @@ func TestLinearVersionPrefix(t *testing.T) {
 
 func TestLinearDeletion(t *testing.T) {
 	t.Run("non full-state resource", func(t *testing.T) {
-		c := NewLinearCache(testType, WithInitialResources(map[string]types.Resource{"a": testResource("a"), "b": testResource("b")}))
+		c := NewLinearCache(testType, WithInitialResources(map[string]types.Resource{"a": testResource("a"), "b": testResource("b")}), WithLogger(log.NewTestLogger(t)))
 		w := make(chan Response, 1)
 		req := &Request{ResourceNames: []string{"a"}, TypeUrl: testType, VersionInfo: "0"}
 		sub := subFromRequest(req)
@@ -510,7 +507,7 @@ func TestLinearDeletion(t *testing.T) {
 		require.NoError(t, err)
 		// b is watched by wildcard, but for non-full-state resources we cannot report deletions
 		mustBlock(t, w)
-		assert.Len(t, c.watchAll, 1)
+		assert.Len(t, c.wildcardWatches.sotw, 1)
 	})
 
 	t.Run("full-state resource", func(t *testing.T) {
@@ -699,7 +696,7 @@ func TestLinearDeltaWildcard(t *testing.T) {
 }
 
 func TestLinearDeltaExistingResources(t *testing.T) {
-	c := NewLinearCache(testType)
+	c := NewLinearCache(testType, WithLogger(log.NewTestLogger(t)))
 	a := &endpoint.ClusterLoadAssignment{ClusterName: "a"}
 	hashA := hashResource(t, a)
 	err := c.UpdateResource("a", a)
@@ -726,7 +723,7 @@ func TestLinearDeltaExistingResources(t *testing.T) {
 }
 
 func TestLinearDeltaInitialResourcesVersionSet(t *testing.T) {
-	c := NewLinearCache(testType)
+	c := NewLinearCache(testType, WithLogger(log.NewTestLogger(t)))
 	a := &endpoint.ClusterLoadAssignment{ClusterName: "a"}
 	hashA := hashResource(t, a)
 	err := c.UpdateResource("a", a)
@@ -768,7 +765,7 @@ func TestLinearDeltaResourceUpdate(t *testing.T) {
 	err = c.UpdateResource("b", b)
 	require.NoError(t, err)
 	// There is currently no delta watch
-	checkVersionMapNotSet(t, c)
+	checkStableVersionsAreNotComputed(t, c)
 
 	req := &DeltaRequest{TypeUrl: testType, ResourceNamesSubscribe: []string{"a", "b"}}
 	w := make(chan DeltaResponse, 1)
@@ -776,7 +773,7 @@ func TestLinearDeltaResourceUpdate(t *testing.T) {
 	require.NoError(t, err)
 	checkDeltaWatchCount(t, c, 0)
 	verifyDeltaResponse(t, w, []resourceInfo{{"b", hashB}, {"a", hashA}}, nil)
-	checkVersionMapSet(t, c)
+	checkStableVersionsAreComputed(t, c)
 
 	req = &DeltaRequest{TypeUrl: testType, ResourceNamesSubscribe: []string{"a", "b"}, InitialResourceVersions: map[string]string{"a": hashA, "b": hashB}}
 	w = make(chan DeltaResponse, 1)
@@ -792,7 +789,7 @@ func TestLinearDeltaResourceUpdate(t *testing.T) {
 	err = c.UpdateResource("a", a)
 	require.NoError(t, err)
 	verifyDeltaResponse(t, w, []resourceInfo{{"a", hashA}}, nil)
-	checkVersionMapSet(t, c)
+	checkStableVersionsAreComputed(t, c)
 }
 
 func TestLinearDeltaResourceDelete(t *testing.T) {
@@ -832,7 +829,7 @@ func TestLinearDeltaMultiResourceUpdates(t *testing.T) {
 	c := NewLinearCache(testType)
 
 	w := make(chan DeltaResponse, 1)
-	checkVersionMapNotSet(t, c)
+	checkStableVersionsAreNotComputed(t, c)
 	assert.Equal(t, 0, c.NumResources())
 
 	// Initial update
@@ -843,7 +840,7 @@ func TestLinearDeltaMultiResourceUpdates(t *testing.T) {
 	mustBlockDelta(t, w)
 	checkDeltaWatchCount(t, c, 1)
 	// The version map should now be created, even if empty
-	checkVersionMapSet(t, c)
+	checkStableVersionsAreComputed(t, c)
 	a := &endpoint.ClusterLoadAssignment{ClusterName: "a"}
 	hashA := hashResource(t, a)
 	b := &endpoint.ClusterLoadAssignment{ClusterName: "b"}
@@ -852,7 +849,7 @@ func TestLinearDeltaMultiResourceUpdates(t *testing.T) {
 	require.NoError(t, err)
 	resp := <-w
 	validateDeltaResponse(t, resp, []resourceInfo{{"a", hashA}, {"b", hashB}}, nil)
-	checkVersionMapSet(t, c)
+	checkStableVersionsAreComputed(t, c)
 	assert.Equal(t, 2, c.NumResources())
 
 	sub.SetReturnedResources(resp.GetNextVersionMap())
@@ -875,7 +872,7 @@ func TestLinearDeltaMultiResourceUpdates(t *testing.T) {
 	require.NoError(t, err)
 	resp = <-w
 	validateDeltaResponse(t, resp, []resourceInfo{{"a", hashA}, {"b", hashB}}, nil)
-	checkVersionMapSet(t, c)
+	checkStableVersionsAreComputed(t, c)
 	assert.Equal(t, 2, c.NumResources())
 	sub.SetReturnedResources(resp.GetNextVersionMap())
 
@@ -895,7 +892,7 @@ func TestLinearDeltaMultiResourceUpdates(t *testing.T) {
 	assert.NotContains(t, c.resources, "b", "resource with name b was found in cache")
 	resp = <-w
 	validateDeltaResponse(t, resp, []resourceInfo{{"a", hashA}}, []string{"b"})
-	checkVersionMapSet(t, c)
+	checkStableVersionsAreComputed(t, c)
 	assert.Equal(t, 2, c.NumResources())
 	sub.SetReturnedResources(resp.GetNextVersionMap())
 
@@ -912,7 +909,7 @@ func TestLinearDeltaMultiResourceUpdates(t *testing.T) {
 	assert.NotContains(t, c.resources, "d", "resource with name d was found in cache")
 	resp = <-w
 	validateDeltaResponse(t, resp, []resourceInfo{{"b", hashB}}, nil) // d is not watched and should not be returned
-	checkVersionMapSet(t, c)
+	checkStableVersionsAreComputed(t, c)
 	assert.Equal(t, 2, c.NumResources())
 	sub.SetReturnedResources(resp.GetNextVersionMap())
 
@@ -929,7 +926,7 @@ func TestLinearDeltaMultiResourceUpdates(t *testing.T) {
 	err = c.UpdateResources(map[string]types.Resource{"b": b, "d": d}, nil)
 	require.NoError(t, err)
 	verifyDeltaResponse(t, w, []resourceInfo{{"b", hashB}, {"d", hashD}}, nil)
-	checkVersionMapSet(t, c)
+	checkStableVersionsAreComputed(t, c)
 	assert.Equal(t, 3, c.NumResources())
 
 	// Wildcard update/delete
@@ -947,7 +944,7 @@ func TestLinearDeltaMultiResourceUpdates(t *testing.T) {
 
 	checkDeltaWatchCount(t, c, 0)
 	// Confirm that the map is still set even though there is currently no watch
-	checkVersionMapSet(t, c)
+	checkStableVersionsAreComputed(t, c)
 	assert.Equal(t, 2, c.NumResources())
 }
 
@@ -969,7 +966,7 @@ func TestLinearMixedWatches(t *testing.T) {
 	_, err = c.CreateWatch(sotwReq, sotwSub, w)
 	require.NoError(t, err)
 	mustBlock(t, w)
-	checkVersionMapNotSet(t, c)
+	checkStableVersionsAreNotComputed(t, c)
 
 	a = &endpoint.ClusterLoadAssignment{ClusterName: "a", Endpoints: []*endpoint.LocalityLbEndpoints{ // resource update
 		{Priority: 25},
@@ -980,13 +977,13 @@ func TestLinearMixedWatches(t *testing.T) {
 	// This behavior is currently invalid for cds and lds, but due to a current limitation of linear cache sotw implementation
 	resp := verifyResponseResources(t, w, resource.EndpointType, c.getVersion(), "a")
 	updateFromSotwResponse(resp, &sotwSub, sotwReq)
-	checkVersionMapNotSet(t, c)
+	checkStableVersionsAreNotComputed(t, c)
 
 	sotwReq.VersionInfo = c.getVersion()
 	_, err = c.CreateWatch(sotwReq, sotwSub, w)
 	require.NoError(t, err)
 	mustBlock(t, w)
-	checkVersionMapNotSet(t, c)
+	checkStableVersionsAreNotComputed(t, c)
 
 	deltaReq := &DeltaRequest{TypeUrl: resource.EndpointType, ResourceNamesSubscribe: []string{"a", "b"}, InitialResourceVersions: map[string]string{"a": hashA, "b": hashB}}
 	wd := make(chan DeltaResponse, 1)
@@ -996,11 +993,11 @@ func TestLinearMixedWatches(t *testing.T) {
 	require.NoError(t, err)
 	mustBlockDelta(t, wd)
 	checkDeltaWatchCount(t, c, 1)
-	checkVersionMapSet(t, c)
+	checkStableVersionsAreComputed(t, c)
 
 	err = c.UpdateResources(nil, []string{"b"})
 	require.NoError(t, err)
-	checkVersionMapSet(t, c)
+	checkStableVersionsAreComputed(t, c)
 	mustBlock(t, w) // For sotw with non full-state resources, we don't report deletions
 	verifyDeltaResponse(t, wd, nil, []string{"b"}, responseType(resource.EndpointType))
 }
@@ -1027,11 +1024,11 @@ func TestLinearSotwWatches(t *testing.T) {
 		_, err = cache.CreateWatch(sotwReq, sotwSub, w)
 		require.NoError(t, err)
 		mustBlock(t, w)
-		checkVersionMapNotSet(t, cache)
+		checkStableVersionsAreNotComputed(t, cache)
 
-		assert.Len(t, cache.watches["a"], 1)
-		assert.Len(t, cache.watches["b"], 1)
-		assert.Len(t, cache.watches["c"], 1)
+		assert.Len(t, cache.resourceWatches["a"].sotw, 1)
+		assert.Len(t, cache.resourceWatches["b"].sotw, 1)
+		assert.Len(t, cache.resourceWatches["c"].sotw, 1)
 
 		// Update a and c without touching b
 		a = &endpoint.ClusterLoadAssignment{ClusterName: "a", Endpoints: []*endpoint.LocalityLbEndpoints{ // resource update
@@ -1041,11 +1038,11 @@ func TestLinearSotwWatches(t *testing.T) {
 		require.NoError(t, err)
 		resp := verifyResponseResources(t, w, testType, cache.getVersion(), "a")
 		updateFromSotwResponse(resp, &sotwSub, sotwReq)
-		checkVersionMapNotSet(t, cache)
+		checkStableVersionsAreNotComputed(t, cache)
 
-		assert.Empty(t, cache.watches["a"])
-		assert.Empty(t, cache.watches["b"])
-		assert.Empty(t, cache.watches["c"])
+		assert.Empty(t, cache.resourceWatches["a"].sotw)
+		assert.Empty(t, cache.resourceWatches["b"].sotw)
+		assert.Empty(t, cache.resourceWatches["c"].sotw)
 
 		// c no longer watched
 		w = make(chan Response, 1)
@@ -1054,21 +1051,21 @@ func TestLinearSotwWatches(t *testing.T) {
 		_, err = cache.CreateWatch(sotwReq, sotwSub, w)
 		require.NoError(t, err)
 		mustBlock(t, w)
-		checkVersionMapNotSet(t, cache)
+		checkStableVersionsAreNotComputed(t, cache)
 
 		b = &endpoint.ClusterLoadAssignment{ClusterName: "b", Endpoints: []*endpoint.LocalityLbEndpoints{ // resource update
 			{Priority: 15},
 		}}
 		err = cache.UpdateResources(map[string]types.Resource{"b": b}, nil)
 
-		assert.Empty(t, cache.watches["a"])
-		assert.Empty(t, cache.watches["b"])
-		assert.Empty(t, cache.watches["c"])
+		assert.Empty(t, cache.resourceWatches["a"].sotw)
+		assert.Empty(t, cache.resourceWatches["b"].sotw)
+		assert.Empty(t, cache.resourceWatches["c"].sotw)
 
 		require.NoError(t, err)
 		resp = verifyResponseResources(t, w, testType, cache.getVersion(), "b")
 		updateFromSotwResponse(resp, &sotwSub, sotwReq)
-		checkVersionMapNotSet(t, cache)
+		checkStableVersionsAreNotComputed(t, cache)
 
 		w = make(chan Response, 1)
 		sotwReq.ResourceNames = []string{"c"}
@@ -1076,7 +1073,7 @@ func TestLinearSotwWatches(t *testing.T) {
 		_, err = cache.CreateWatch(sotwReq, sotwSub, w)
 		require.NoError(t, err)
 		mustBlock(t, w)
-		checkVersionMapNotSet(t, cache)
+		checkStableVersionsAreNotComputed(t, cache)
 
 		c := &endpoint.ClusterLoadAssignment{ClusterName: "c", Endpoints: []*endpoint.LocalityLbEndpoints{ // resource update
 			{Priority: 15},
@@ -1084,11 +1081,11 @@ func TestLinearSotwWatches(t *testing.T) {
 		err = cache.UpdateResources(map[string]types.Resource{"c": c}, nil)
 		require.NoError(t, err)
 		verifyResponseResources(t, w, testType, cache.getVersion(), "c")
-		checkVersionMapNotSet(t, cache)
+		checkStableVersionsAreNotComputed(t, cache)
 
-		assert.Empty(t, cache.watches["a"])
-		assert.Empty(t, cache.watches["b"])
-		assert.Empty(t, cache.watches["c"])
+		assert.Empty(t, cache.resourceWatches["a"].sotw)
+		assert.Empty(t, cache.resourceWatches["b"].sotw)
+		assert.Empty(t, cache.resourceWatches["c"].sotw)
 	})
 
 	t.Run("watches return full state for types requesting it", func(t *testing.T) {
@@ -1111,7 +1108,7 @@ func TestLinearSotwWatches(t *testing.T) {
 		_, err := cache.CreateWatch(nonWildcardReq, nonWildcardSub, w1)
 		require.NoError(t, err)
 		mustBlock(t, w1)
-		checkVersionMapNotSet(t, cache)
+		checkStableVersionsAreNotComputed(t, cache)
 
 		// wildcard request
 		wildcardReq := &Request{ResourceNames: nil, TypeUrl: resource.ClusterType, VersionInfo: cache.getVersion()}
@@ -1121,7 +1118,7 @@ func TestLinearSotwWatches(t *testing.T) {
 		_, err = cache.CreateWatch(wildcardReq, wildcardSub, w2)
 		require.NoError(t, err)
 		mustBlock(t, w2)
-		checkVersionMapNotSet(t, cache)
+		checkStableVersionsAreNotComputed(t, cache)
 
 		// request not requesting b
 		otherReq := &Request{ResourceNames: []string{"a", "c", "d"}, TypeUrl: resource.ClusterType, VersionInfo: cache.getVersion()}
@@ -1131,7 +1128,7 @@ func TestLinearSotwWatches(t *testing.T) {
 		_, err = cache.CreateWatch(otherReq, otherSub, w3)
 		require.NoError(t, err)
 		mustBlock(t, w3)
-		checkVersionMapNotSet(t, cache)
+		checkStableVersionsAreNotComputed(t, cache)
 
 		b.AltStatName = "othername"
 		err = cache.UpdateResources(map[string]types.Resource{"b": b}, nil)
@@ -1301,12 +1298,12 @@ func TestLinearSotwNonWildcard(t *testing.T) {
 		checkPendingWatch(4)
 
 		// Cancel two watches to change resources
-		assert.Len(t, cache.watches["c"], 2)
+		assert.Len(t, cache.resourceWatches["c"].sotw, 2)
 		c2()
-		assert.Len(t, cache.watches["c"], 1)
-		assert.Len(t, cache.watches["b"], 1)
+		assert.Len(t, cache.resourceWatches["c"].sotw, 1)
+		assert.Len(t, cache.resourceWatches["b"].sotw, 1)
 		c3()
-		assert.Len(t, cache.watches["b"], 0)
+		assert.Len(t, cache.resourceWatches["b"].sotw, 0)
 
 		// Remove a resource from 2 (was a, c, d)
 		updateReqResources(2, []string{"a", "d"})
@@ -1427,12 +1424,12 @@ func TestLinearSotwNonWildcard(t *testing.T) {
 		checkPendingWatch(4)
 
 		// Cancel two watches to change resources
-		assert.Len(t, cache.watches["c"], 2)
+		assert.Len(t, cache.resourceWatches["c"].sotw, 2)
 		c2()
-		assert.Len(t, cache.watches["c"], 1)
-		assert.Len(t, cache.watches["b"], 1)
+		assert.Len(t, cache.resourceWatches["c"].sotw, 1)
+		assert.Len(t, cache.resourceWatches["b"].sotw, 1)
 		c3()
-		assert.Len(t, cache.watches["b"], 0)
+		assert.Len(t, cache.resourceWatches["b"].sotw, 0)
 
 		// Remove a resource from 2 (was a, c, d)
 		updateReqResources(2, []string{"a", "d"})

--- a/pkg/cache/v3/simple.go
+++ b/pkg/cache/v3/simple.go
@@ -590,10 +590,9 @@ func (cache *snapshotCache) CreateDeltaWatch(request *DeltaRequest, sub Subscrip
 // Respond to a delta watch with the provided snapshot value. If the response is nil, there has been no state change.
 func (cache *snapshotCache) respondDelta(ctx context.Context, snapshot ResourceSnapshot, request *DeltaRequest, value chan DeltaResponse, sub Subscription) (*RawDeltaResponse, error) {
 	resp := createDeltaResponse(ctx, request, sub, resourceContainer{
-		resourceMap:   snapshot.GetResources(request.GetTypeUrl()),
-		versionMap:    snapshot.GetVersionMap(request.GetTypeUrl()),
-		systemVersion: snapshot.GetVersion(request.GetTypeUrl()),
-	})
+		resourceMap: snapshot.GetResources(request.GetTypeUrl()),
+		versionMap:  snapshot.GetVersionMap(request.GetTypeUrl()),
+	}, snapshot.GetVersion(request.GetTypeUrl()))
 
 	// Only send a response if there were changes
 	// We want to respond immediately for the first wildcard request in a stream, even if the response is empty

--- a/pkg/cache/v3/snapshot.go
+++ b/pkg/cache/v3/snapshot.go
@@ -188,16 +188,10 @@ func (s *Snapshot) ConstructVersionMap() error {
 		}
 
 		for _, r := range resources.Items {
-			// Hash our version in here and build the version map.
-			marshaledResource, err := MarshalResource(r.Resource)
+			v, err := computeResourceStableVersion(r.Resource)
 			if err != nil {
-				return err
-			}
-			v := HashResource(marshaledResource)
-			if v == "" {
 				return fmt.Errorf("failed to build resource version: %w", err)
 			}
-
 			s.VersionMap[typeURL][GetResourceName(r.Resource)] = v
 		}
 	}

--- a/pkg/server/stream/v3/subscription.go
+++ b/pkg/server/stream/v3/subscription.go
@@ -163,21 +163,6 @@ func (s Subscription) IsWildcard() bool {
 	return s.wildcard
 }
 
-// WatchesResources returns whether at least one of the resources provided is currently being watched by the subscription.
-// If the request is wildcard, it will always return true,
-// otherwise it will compare the provided resources to the list of resources currently subscribed
-func (s Subscription) WatchesResources(resourceNames map[string]struct{}) bool {
-	if s.wildcard {
-		return true
-	}
-	for resourceName := range resourceNames {
-		if _, ok := s.subscribedResourceNames[resourceName]; ok {
-			return true
-		}
-	}
-	return false
-}
-
 // ReturnedResources returns the list of resources returned to the client
 // and their version
 func (s Subscription) ReturnedResources() map[string]string {


### PR DESCRIPTION
Following the previous PRs, the implementation of linear cache has become more common between sotw and delta watches. This PR makes it clearer and reorganize the setup:
 - reorganize resource cache and watch tracking per resource, instead of per mode. This will enable changes like sotw using resource versions
 - avoid multiple marshaling of the resource when the version is already computed through marshaling (not in this PR, as potentially impactful on memory)
 - sotw and delta watches use a common model for their handling, with common code to compute subscription impact vs. cache. Only the generation of the response is different