### PR TITLE
[Linear cache] Support use of stable versions in sotw

### DIFF
--- a/pkg/cache/v3/linear.go
+++ b/pkg/cache/v3/linear.go
@@ -16,8 +16,11 @@ package cache
 
 import (
 	"context"
+	"encoding/hex"
 	"errors"
 	"fmt"
+	"hash/fnv"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -36,6 +39,13 @@ type cachedResource struct {
 	// stableVersion is the version of the resource itself (a hash of its content after deterministic marshaling).
 	// It is lazy initialized and should be accessed through getStableVersion.
 	stableVersion string
+}
+
+func newCachedResource(res types.Resource, cacheVersion string) *cachedResource {
+	return &cachedResource{
+		Resource:     res,
+		cacheVersion: cacheVersion,
+	}
 }
 
 func (c *cachedResource) getStableVersion() (string, error) {
@@ -108,6 +118,10 @@ type LinearCache struct {
 	// cache instances and avoid issues of version reuse.
 	versionPrefix string
 
+	// useStableVersionsInSotw switches to a new version model for sotw watches.
+	// The version is then encoding the known resources of the subscription
+	useStableVersionsInSotw bool
+
 	log log.Logger
 
 	mu sync.RWMutex
@@ -121,6 +135,8 @@ type LinearCacheOption func(*LinearCache)
 // WithVersionPrefix sets a version prefix of the form "prefixN" in the version info.
 // Version prefix can be used to distinguish replicated instances of the cache, in case
 // a client re-connects to another instance.
+// Deprecated: use WithSotwStableVersions instead to avoid issues when reconnecting to other instances
+// while avoiding resending resources if unchanged.
 func WithVersionPrefix(prefix string) LinearCacheOption {
 	return func(cache *LinearCache) {
 		cache.versionPrefix = prefix
@@ -141,6 +157,18 @@ func WithInitialResources(resources map[string]types.Resource) LinearCacheOption
 func WithLogger(log log.Logger) LinearCacheOption {
 	return func(cache *LinearCache) {
 		cache.log = log
+	}
+}
+
+// WithSotwStableVersions changes the versions returned in sotw to encode the list of resources known
+// in the subscription.
+// The use of stable versions for sotw also deduplicates updates to clients if the cache updates are
+// not changing the content of the resource.
+// When used, the use of WithVersionPrefix is no longer needed to manage reconnection to other instances
+// and should not be used.
+func WithSotwStableVersions() LinearCacheOption {
+	return func(cache *LinearCache) {
+		cache.useStableVersionsInSotw = true
 	}
 }
 
@@ -250,61 +278,89 @@ func (cache *LinearCache) computeResourceChange(sub Subscription, alwaysConsider
 	return changedResources, removedResources, nil
 }
 
+func computeSotwStableVersion(versionMap map[string]string) string {
+	keys := make([]string, 0, len(versionMap))
+	for key := range versionMap {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	// Reuse the hash used on resources.
+	hasher := fnv.New64a()
+	for _, key := range keys {
+		hasher.Write([]byte(key))
+		hasher.Write([]byte("/"))
+		hasher.Write([]byte(versionMap[key]))
+		hasher.Write([]byte("^"))
+	}
+	return hex.EncodeToString(hasher.Sum(nil))
+}
+
 func (cache *LinearCache) computeSotwResponse(watch ResponseWatch, alwaysConsiderAllResources bool) (*RawResponse, error) {
-	changedResources, removedResources, err := cache.computeResourceChange(watch.subscription, alwaysConsiderAllResources, false)
+	changedResources, removedResources, err := cache.computeResourceChange(watch.subscription, alwaysConsiderAllResources, cache.useStableVersionsInSotw)
 	if err != nil {
 		return nil, err
 	}
-
 	if len(changedResources) == 0 && len(removedResources) == 0 && !alwaysConsiderAllResources {
 		// Nothing changed.
 		return nil, nil
 	}
 
+	// In sotw the list of resources to actually return depends on:
+	//  - whether the type requires full-state in each reply (e.g. lds, cds).
+	//  - whether the request is wildcard.
+	// resourcesToReturn will include all the resource names to reply based on the changes detected.
+	var resourcesToReturn []string
+
+	switch {
+	// For lds and cds, answers will always include all existing subscribed resources, with no regard to which resource was changed or removed.
+	// For other types, the response only includes updated resources (sotw cannot notify for deletion).
+	case !ResourceRequiresFullStateInSotw(cache.typeURL):
+		if !alwaysConsiderAllResources && len(changedResources) == 0 {
+			// If the request is not the initial one, and the type does not require full updates,
+			// do not return if nothing is to be set.
+			// For full-state resources an empty response does have a semantic meaning.
+			return nil, nil
+		}
+
+		// changedResources is already filtered based on the subscription.
+		resourcesToReturn = changedResources
+	case watch.subscription.IsWildcard():
+		// Include all resources for the type.
+		resourcesToReturn = make([]string, 0, len(cache.resources))
+		for resourceName := range cache.resources {
+			resourcesToReturn = append(resourcesToReturn, resourceName)
+		}
+	default:
+		// Include all resources matching the subscription, with no concern on whether it has been updated or not.
+		requestedResources := watch.subscription.SubscribedResources()
+		// The linear cache could be very large (e.g. containing all potential CLAs)
+		// Therefore drives on the subscription requested resources.
+		resourcesToReturn = make([]string, 0, len(requestedResources))
+		for resourceName := range requestedResources {
+			if _, ok := cache.resources[resourceName]; ok {
+				resourcesToReturn = append(resourcesToReturn, resourceName)
+			}
+		}
+	}
+
+	// returnedVersions includes all resources currently known to the subscription and their version.
 	returnedVersions := make(map[string]string, len(watch.subscription.ReturnedResources()))
-	// Clone the current returned versions. The cache should not alter the subscription
+	// Clone the current returned versions. The cache should not alter the subscription.
 	for resourceName, version := range watch.subscription.ReturnedResources() {
 		returnedVersions[resourceName] = version
 	}
 
-	cacheVersion := cache.getVersion()
-	var resources []types.ResourceWithTTL
-
-	switch {
-	// For lds and cds, answers will always include all matching resources, with no regard to which resource was changed or removed.
-	// For other types, the response only includes updated resources (sotw cannot notify for deletion).
-	case !ResourceRequiresFullStateInSotw(cache.typeURL):
-		// changedResources is already filtered based on the subscription.
-		resources = make([]types.ResourceWithTTL, 0, len(changedResources))
-		for _, resourceName := range changedResources {
-			cachedResource := cache.resources[resourceName]
-			resources = append(resources, types.ResourceWithTTL{Resource: cachedResource.Resource})
-			returnedVersions[resourceName] = cachedResource.cacheVersion
+	resources := make([]types.ResourceWithTTL, 0, len(resourcesToReturn))
+	for _, resourceName := range resourcesToReturn {
+		cachedResource := cache.resources[resourceName]
+		resources = append(resources, types.ResourceWithTTL{Resource: cachedResource.Resource})
+		version, err := cachedResource.getVersion(cache.useStableVersionsInSotw)
+		if err != nil {
+			return nil, fmt.Errorf("failed to compute version of %s: %w", resourceName, err)
 		}
-	case watch.subscription.IsWildcard():
-		// Include all resources for the type.
-		resources = make([]types.ResourceWithTTL, 0, len(cache.resources))
-		for resourceName, cachedResource := range cache.resources {
-			resources = append(resources, types.ResourceWithTTL{Resource: cachedResource.Resource})
-			returnedVersions[resourceName] = cachedResource.cacheVersion
-		}
-	default:
-		// Include all resources matching the subscription, with no concern on whether
-		// it has been updated or not.
-		requestedResources := watch.subscription.SubscribedResources()
-		// The linear cache could be very large (e.g. containing all potential CLAs)
-		// Therefore drives on the subscription requested resources.
-		resources = make([]types.ResourceWithTTL, 0, len(requestedResources))
-		for resourceName := range requestedResources {
-			cachedResource, ok := cache.resources[resourceName]
-			if !ok {
-				continue
-			}
-			resources = append(resources, types.ResourceWithTTL{Resource: cachedResource.Resource})
-			returnedVersions[resourceName] = cachedResource.cacheVersion
-		}
+		returnedVersions[resourceName] = version
 	}
-
 	// Cleanup resources no longer existing in the cache or no longer subscribed.
 	// In sotw we cannot return those if not full state,
 	// but this ensures we detect unsubscription then resubscription.
@@ -312,18 +368,16 @@ func (cache *LinearCache) computeSotwResponse(watch ResponseWatch, alwaysConside
 		delete(returnedVersions, resourceName)
 	}
 
-	if !alwaysConsiderAllResources && !ResourceRequiresFullStateInSotw(cache.typeURL) && len(resources) == 0 {
-		// If the request is not the initial one, and the type does not require full updates,
-		// do not return if nothing is to be set.
-		// For full-state resources an empty response does have a semantic meaning.
-		return nil, nil
+	responseVersion := cache.getVersion()
+	if cache.useStableVersionsInSotw {
+		responseVersion = cache.versionPrefix + computeSotwStableVersion(returnedVersions)
 	}
 
 	return &RawResponse{
 		Request:           watch.Request,
 		Resources:         resources,
 		ReturnedResources: returnedVersions,
-		Version:           cacheVersion,
+		Version:           responseVersion,
 		Ctx:               context.Background(),
 	}, nil
 }
@@ -445,25 +499,6 @@ func (cache *LinearCache) notifyAll(modified []string) error {
 	return nil
 }
 
-func computeResourceStableVersion(res types.Resource) (string, error) {
-	// TODO(valerian-roche): store serialized resource as part of the cachedResource
-	// to reuse it when marshaling the responses instead of remarshaling and recomputing the version then.
-	marshaledResource, err := MarshalResource(res)
-	if err != nil {
-		return "", err
-	}
-	return HashResource(marshaledResource), nil
-}
-
-func (cache *LinearCache) addResourceToCache(name string, res types.Resource) error {
-	update := &cachedResource{
-		Resource:     res,
-		cacheVersion: cache.getVersion(),
-	}
-	cache.resources[name] = update
-	return nil
-}
-
 // UpdateResource updates a resource in the collection.
 func (cache *LinearCache) UpdateResource(name string, res types.Resource) error {
 	if res == nil {
@@ -473,9 +508,7 @@ func (cache *LinearCache) UpdateResource(name string, res types.Resource) error 
 	defer cache.mu.Unlock()
 
 	cache.version++
-	if err := cache.addResourceToCache(name, res); err != nil {
-		return err
-	}
+	cache.resources[name] = newCachedResource(res, cache.getVersion())
 
 	return cache.notifyAll([]string{name})
 }
@@ -499,11 +532,10 @@ func (cache *LinearCache) UpdateResources(toUpdate map[string]types.Resource, to
 	defer cache.mu.Unlock()
 
 	cache.version++
+	version := cache.getVersion()
 	modified := make([]string, 0, len(toUpdate)+len(toDelete))
 	for name, resource := range toUpdate {
-		if err := cache.addResourceToCache(name, resource); err != nil {
-			return err
-		}
+		cache.resources[name] = newCachedResource(resource, version)
 		modified = append(modified, name)
 	}
 	for _, name := range toDelete {
@@ -521,6 +553,7 @@ func (cache *LinearCache) SetResources(resources map[string]types.Resource) {
 	defer cache.mu.Unlock()
 
 	cache.version++
+	version := cache.getVersion()
 
 	modified := make([]string, 0, len(resources))
 	// Collect deleted resource names.
@@ -531,13 +564,11 @@ func (cache *LinearCache) SetResources(resources map[string]types.Resource) {
 		}
 	}
 
-	// Collect changed resource names.
 	// We assume all resources passed to SetResources are changed.
-	// Otherwise we would have to do proto.Equal on resources which is pretty expensive operation
+	// In delta and if stable versions are used for sotw, identical resources will not trigger watches.
+	// In sotw without stable versions used, all those resources will trigger watches, even if identical.
 	for name, resource := range resources {
-		if err := cache.addResourceToCache(name, resource); err != nil {
-			cache.log.Errorf("Failed to add resources to the cache: %s", err)
-		}
+		cache.resources[name] = newCachedResource(resource, version)
 		modified = append(modified, name)
 	}
 
@@ -598,8 +629,27 @@ func (cache *LinearCache) CreateWatch(request *Request, sub Subscription, value 
 	if err != nil {
 		return nil, fmt.Errorf("failed to compute the watch respnse: %w", err)
 	}
-
+	shouldReply := false
 	if response != nil {
+		// If the request
+		//  - is the first
+		//  - provides a non-empty version, matching the version prefix
+		// and the cache uses stable versions, if the generated versions are the same as the previous one, we do not return the response.
+		// This avoids resending all data if the new subscription is just a resumption of the previous one.
+		if cache.useStableVersionsInSotw && request.GetResponseNonce() == "" && !ignoreCurrentSubscriptionResources {
+			shouldReply = request.GetVersionInfo() != response.Version
+
+			// We confirmed the content of the known resources, store them in the watch we create.
+			subscription := newWatchSubscription(sub)
+			subscription.returnedResources = response.ReturnedResources
+			watch.subscription = subscription
+			sub = subscription
+		} else {
+			shouldReply = true
+		}
+	}
+
+	if shouldReply {
 		cache.log.Debugf("[linear cache] replying to the watch with resources %v (subscription values %v, known %v)", response.GetReturnedResources(), sub.SubscribedResources(), sub.ReturnedResources())
 		watch.Response <- response
 		return func() {}, nil
@@ -608,7 +658,7 @@ func (cache *LinearCache) CreateWatch(request *Request, sub Subscription, value 
 	watchID := cache.nextWatchID()
 	// Create open watches since versions are up to date.
 	if sub.IsWildcard() {
-		cache.log.Infof("[linear cache] open watch %d for %s all resources, system version %q", watchID, cache.typeURL, cache.getVersion())
+		cache.log.Infof("[linear cache] open watch %d for %s all resources, known versions %v, system version %q", watchID, cache.typeURL, sub.ReturnedResources(), cache.getVersion())
 		cache.wildcardWatches.sotw[watchID] = watch
 		return func() {
 			cache.mu.Lock()
@@ -617,7 +667,7 @@ func (cache *LinearCache) CreateWatch(request *Request, sub Subscription, value 
 		}, nil
 	}
 
-	cache.log.Infof("[linear cache] open watch %d for %s resources %v, system version %q", watchID, cache.typeURL, sub.SubscribedResources(), cache.getVersion())
+	cache.log.Infof("[linear cache] open watch %d for %s resources %v, known versions %v, system version %q", watchID, cache.typeURL, sub.SubscribedResources(), sub.ReturnedResources(), cache.getVersion())
 	for name := range sub.SubscribedResources() {
 		watches, exists := cache.resourceWatches[name]
 		if !exists {

--- a/pkg/cache/v3/linear_test.go
+++ b/pkg/cache/v3/linear_test.go
@@ -1476,7 +1476,7 @@ func TestLinearSotwVersion(t *testing.T) {
 		w := make(chan Response, 1)
 		_, err := cache.CreateWatch(req, subFromRequest(req), w)
 		require.NoError(t, err)
-		resp := verifyResponseResources(t, w, resource.EndpointType, "1d0dadc055487bf8", "a", "b")
+		resp := verifyResponseResources(t, w, resource.EndpointType, "f8fac96556140daa", "a", "b")
 		lastVersion, err = resp.GetVersion()
 		require.NoError(t, err)
 		assert.NotEmpty(t, lastVersion)
@@ -1513,7 +1513,7 @@ func TestLinearSotwVersion(t *testing.T) {
 		w := make(chan Response, 1)
 		_, err := cache.CreateWatch(req, subFromRequest(req), w)
 		require.NoError(t, err)
-		verifyResponseResources(t, w, resource.EndpointType, "test-prefix-1d0dadc055487bf8", "a", "b")
+		verifyResponseResources(t, w, resource.EndpointType, "test-prefix-"+lastVersion, "a", "b")
 	})
 
 	t.Run("watch opened with the same last version including prefix", func(t *testing.T) {
@@ -1543,7 +1543,7 @@ func TestLinearSotwVersion(t *testing.T) {
 
 		_ = cache.UpdateResource("e", &endpoint.ClusterLoadAssignment{ClusterName: "e"})
 		// Resources a and b are still at the proper version, so not returned
-		resp := verifyResponseResources(t, w, resource.EndpointType, "ef89d29eb6398b90", "e")
+		resp := verifyResponseResources(t, w, resource.EndpointType, "6ae65ee0b0c2bfa8", "e")
 		updateFromSotwResponse(resp, &sub, req)
 
 		w = make(chan Response, 1)
@@ -1558,12 +1558,12 @@ func TestLinearSotwVersion(t *testing.T) {
 			EndpointStaleAfter: durationpb.New(5 * time.Second),
 		}})
 		// Resources a and b are still at the proper version, so not returned
-		verifyResponseResources(t, w, resource.EndpointType, "51d88a339c93515b", "e")
+		verifyResponseResources(t, w, resource.EndpointType, "633e4f7cb4f55524", "e")
 
 		_ = cache.UpdateResource("e", &endpoint.ClusterLoadAssignment{ClusterName: "e"})
 
 		// Another watch created with the proper version does not trigger
-		req2 := buildRequest([]string{"a", "b", "e"}, "ef89d29eb6398b90")
+		req2 := buildRequest([]string{"a", "b", "e"}, "6ae65ee0b0c2bfa8")
 		sub2 := subFromRequest(req2)
 		w = make(chan Response, 1)
 		_, err = cache.CreateWatch(req2, sub2, w)
@@ -1577,7 +1577,7 @@ func TestLinearSotwVersion(t *testing.T) {
 		w := make(chan Response, 1)
 		_, err := cache.CreateWatch(req, subFromRequest(req), w)
 		require.NoError(t, err)
-		verifyResponseResources(t, w, resource.EndpointType, "be5530af715f4980", "a", "b", "c", "e")
+		verifyResponseResources(t, w, resource.EndpointType, "68113a35fda99df9", "a", "b", "c", "e")
 	})
 
 	t.Run("watch opened with the same last version and returning less resources", func(t *testing.T) {
@@ -1586,6 +1586,6 @@ func TestLinearSotwVersion(t *testing.T) {
 		w := make(chan Response, 1)
 		_, err := cache.CreateWatch(req, subFromRequest(req), w)
 		require.NoError(t, err)
-		verifyResponseResources(t, w, resource.EndpointType, "0aa479b0bd7e5474", "a")
+		verifyResponseResources(t, w, resource.EndpointType, "55876f045443ee06", "a")
 	})
 }

--- a/pkg/cache/v3/linear_test.go
+++ b/pkg/cache/v3/linear_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
@@ -503,7 +504,7 @@ func TestLinearDeletion(t *testing.T) {
 	})
 
 	t.Run("full-state resource", func(t *testing.T) {
-		c := NewLinearCache(resource.ClusterType, WithInitialResources(map[string]types.Resource{"a": &cluster.Cluster{Name: "a"}, "b": &cluster.Cluster{Name: "b"}}))
+		c := NewLinearCache(resource.ClusterType, WithInitialResources(map[string]types.Resource{"a": &cluster.Cluster{Name: "a"}, "b": &cluster.Cluster{Name: "b"}}), WithLogger(log.NewTestLogger(t)))
 		w := make(chan Response, 1)
 		req := &Request{ResourceNames: []string{"a"}, TypeUrl: resource.ClusterType, VersionInfo: "0"}
 		sub := subFromRequest(req)
@@ -1448,5 +1449,143 @@ func TestLinearSotwNonWildcard(t *testing.T) {
 		validateResponse(2, []string{"a", "d"})
 		validateResponse(3, []string{"a", "b", "d", "e"})
 		checkPendingWatch(4)
+	})
+}
+
+func TestLinearSotwVersion(t *testing.T) {
+	cache := NewLinearCache(resource.EndpointType, WithLogger(log.NewTestLogger(t)), WithInitialResources(
+		map[string]types.Resource{
+			"a": &endpoint.ClusterLoadAssignment{ClusterName: "a"},
+			"b": &endpoint.ClusterLoadAssignment{ClusterName: "b"},
+			"c": &endpoint.ClusterLoadAssignment{ClusterName: "c"},
+		},
+	), WithSotwStableVersions())
+
+	buildRequest := func(res []string, version string) *discovery.DiscoveryRequest {
+		return &discovery.DiscoveryRequest{
+			ResourceNames: res,
+			TypeUrl:       resource.EndpointType,
+			VersionInfo:   version,
+		}
+	}
+
+	var lastVersion string
+	t.Run("watch without any version is replied to", func(t *testing.T) {
+		cache.log = log.NewTestLogger(t)
+		req := buildRequest([]string{"a", "b", "d"}, "")
+		w := make(chan Response, 1)
+		_, err := cache.CreateWatch(req, subFromRequest(req), w)
+		require.NoError(t, err)
+		resp := verifyResponseResources(t, w, resource.EndpointType, "1d0dadc055487bf8", "a", "b")
+		lastVersion, err = resp.GetVersion()
+		require.NoError(t, err)
+		assert.NotEmpty(t, lastVersion)
+	})
+
+	t.Run("watch opened with the same last version", func(t *testing.T) {
+		cache.log = log.NewTestLogger(t)
+		req := buildRequest([]string{"a", "b", "d"}, lastVersion)
+		w := make(chan Response, 1)
+		_, err := cache.CreateWatch(req, subFromRequest(req), w)
+		require.NoError(t, err)
+		mustBlock(t, w)
+	})
+
+	t.Run("watch opened with the same last version and different prefix", func(t *testing.T) {
+		cache.log = log.NewTestLogger(t)
+		req := buildRequest([]string{"a", "b", "d"}, "test-prefix-"+lastVersion)
+		w := make(chan Response, 1)
+		_, err := cache.CreateWatch(req, subFromRequest(req), w)
+		require.NoError(t, err)
+		verifyResponseResources(t, w, resource.EndpointType, lastVersion, "a", "b")
+	})
+
+	t.Run("watch opened with the same last version missing prefix", func(t *testing.T) {
+		cache := NewLinearCache(resource.EndpointType, WithLogger(log.NewTestLogger(t)), WithInitialResources(
+			map[string]types.Resource{
+				"a": &endpoint.ClusterLoadAssignment{ClusterName: "a"},
+				"b": &endpoint.ClusterLoadAssignment{ClusterName: "b"},
+				"c": &endpoint.ClusterLoadAssignment{ClusterName: "c"},
+			},
+		), WithSotwStableVersions(), WithVersionPrefix("test-prefix-"))
+
+		req := buildRequest([]string{"a", "b", "d"}, lastVersion)
+		w := make(chan Response, 1)
+		_, err := cache.CreateWatch(req, subFromRequest(req), w)
+		require.NoError(t, err)
+		verifyResponseResources(t, w, resource.EndpointType, "test-prefix-1d0dadc055487bf8", "a", "b")
+	})
+
+	t.Run("watch opened with the same last version including prefix", func(t *testing.T) {
+		cache := NewLinearCache(resource.EndpointType, WithLogger(log.NewTestLogger(t)), WithInitialResources(
+			map[string]types.Resource{
+				"a": &endpoint.ClusterLoadAssignment{ClusterName: "a"},
+				"b": &endpoint.ClusterLoadAssignment{ClusterName: "b"},
+				"c": &endpoint.ClusterLoadAssignment{ClusterName: "c"},
+			},
+		), WithSotwStableVersions(), WithVersionPrefix("test-prefix-"))
+
+		req := buildRequest([]string{"a", "b", "d"}, "test-prefix-"+lastVersion)
+		w := make(chan Response, 1)
+		_, err := cache.CreateWatch(req, subFromRequest(req), w)
+		require.NoError(t, err)
+		mustBlock(t, w)
+	})
+
+	t.Run("watch opened with the same last version, different resource not changing the response", func(t *testing.T) {
+		cache.log = log.NewTestLogger(t)
+		req := buildRequest([]string{"a", "b", "e"}, lastVersion)
+		sub := subFromRequest(req)
+		w := make(chan Response, 1)
+		_, err := cache.CreateWatch(req, sub, w)
+		require.NoError(t, err)
+		mustBlock(t, w)
+
+		_ = cache.UpdateResource("e", &endpoint.ClusterLoadAssignment{ClusterName: "e"})
+		// Resources a and b are still at the proper version, so not returned
+		resp := verifyResponseResources(t, w, resource.EndpointType, "ef89d29eb6398b90", "e")
+		updateFromSotwResponse(resp, &sub, req)
+
+		w = make(chan Response, 1)
+		_, err = cache.CreateWatch(req, sub, w)
+		require.NoError(t, err)
+		mustBlock(t, w)
+		// Resource is not changed, nothing is returned
+		_ = cache.UpdateResource("e", &endpoint.ClusterLoadAssignment{ClusterName: "e"})
+		mustBlock(t, w)
+
+		_ = cache.UpdateResource("e", &endpoint.ClusterLoadAssignment{ClusterName: "e", Policy: &endpoint.ClusterLoadAssignment_Policy{
+			EndpointStaleAfter: durationpb.New(5 * time.Second),
+		}})
+		// Resources a and b are still at the proper version, so not returned
+		verifyResponseResources(t, w, resource.EndpointType, "51d88a339c93515b", "e")
+
+		_ = cache.UpdateResource("e", &endpoint.ClusterLoadAssignment{ClusterName: "e"})
+
+		// Another watch created with the proper version does not trigger
+		req2 := buildRequest([]string{"a", "b", "e"}, "ef89d29eb6398b90")
+		sub2 := subFromRequest(req2)
+		w = make(chan Response, 1)
+		_, err = cache.CreateWatch(req2, sub2, w)
+		require.NoError(t, err)
+		mustBlock(t, w)
+	})
+
+	t.Run("watch opened with the same last version and returning more resources", func(t *testing.T) {
+		cache.log = log.NewTestLogger(t)
+		req := buildRequest([]string{}, lastVersion)
+		w := make(chan Response, 1)
+		_, err := cache.CreateWatch(req, subFromRequest(req), w)
+		require.NoError(t, err)
+		verifyResponseResources(t, w, resource.EndpointType, "be5530af715f4980", "a", "b", "c", "e")
+	})
+
+	t.Run("watch opened with the same last version and returning less resources", func(t *testing.T) {
+		cache.log = log.NewTestLogger(t)
+		req := buildRequest([]string{"a", "d"}, lastVersion)
+		w := make(chan Response, 1)
+		_, err := cache.CreateWatch(req, subFromRequest(req), w)
+		require.NoError(t, err)
+		verifyResponseResources(t, w, resource.EndpointType, "0aa479b0bd7e5474", "a")
 	})
 }

--- a/pkg/cache/v3/snapshot.go
+++ b/pkg/cache/v3/snapshot.go
@@ -188,10 +188,16 @@ func (s *Snapshot) ConstructVersionMap() error {
 		}
 
 		for _, r := range resources.Items {
-			v, err := computeResourceStableVersion(r.Resource)
+			// Hash our version in here and build the version map.
+			marshaledResource, err := MarshalResource(r.Resource)
 			if err != nil {
+				return err
+			}
+			v := HashResource(marshaledResource)
+			if v == "" {
 				return fmt.Errorf("failed to build resource version: %w", err)
 			}
+
 			s.VersionMap[typeURL][GetResourceName(r.Resource)] = v
 		}
 	}

--- a/pkg/cache/v3/subscription.go
+++ b/pkg/cache/v3/subscription.go
@@ -1,0 +1,37 @@
+package cache
+
+// watchSubscription is used to provide the minimum feature set we need from subscription.
+// As only a few APIs are used, and we don't return the subscription, this allows the cache
+// to store an altered version of the subscription without modifying the immutable one provided.
+type watchSubscription struct {
+	returnedResources   map[string]string
+	subscribedResources map[string]struct{}
+	isWildcard          bool
+}
+
+func (s watchSubscription) ReturnedResources() map[string]string {
+	return s.returnedResources
+}
+
+func (s watchSubscription) SubscribedResources() map[string]struct{} {
+	return s.subscribedResources
+}
+
+func (s watchSubscription) IsWildcard() bool {
+	return s.isWildcard
+}
+
+func newWatchSubscription(s Subscription) watchSubscription {
+	clone := watchSubscription{
+		isWildcard:          s.IsWildcard(),
+		returnedResources:   make(map[string]string, len(s.ReturnedResources())),
+		subscribedResources: make(map[string]struct{}, len(s.SubscribedResources())),
+	}
+	for name, version := range s.ReturnedResources() {
+		clone.returnedResources[name] = version
+	}
+	for name := range s.SubscribedResources() {
+		clone.subscribedResources[name] = struct{}{}
+	}
+	return clone
+}


### PR DESCRIPTION
When using sotw watches, the current behavior of the linear cache is to use the current version of the cache (monotonically increased on resource updates) as the version returned. In the past the request-provided version was compared to the version of the last resource update to compute the returned resources, allowing watch resumption when a client would reconnect. 
This behavior was actually not working as the subscribed resources could change while no cache updates occurred, or the newly requested resources were at an older cache version. PR #10 therefore no longer use this behavior to track resources to be returned, instead relying on the subscription state. 
A side effect is that watch resumption would always return all known resources. Delta watches have a mechanism to avoid this issue, by tracking per resource version and sending them as part of the initial request of a new subscription. 

Sotw do not allow per resource version in requests and responses, but by encoding the current subscription state through a hash of the returned versions map, this PR now allows resumption if the hash matches the response we would otherwise return. 
It still has two main limitations: 
 - it is less efficient (as we compute an entire response to then not reply) 
 - we cannot track which resource (if any) changed, and will therefore return them all if anything has changed.