### PR TITLE
Use lazy computation of stable versions in linear cache

### DIFF
--- a/pkg/cache/v3/cache.go
+++ b/pkg/cache/v3/cache.go
@@ -56,12 +56,6 @@ type Subscription interface {
 	// This considers subtleties related to the current migration of wildcard definitions within the protocol.
 	// More details on the behavior of wildcard are present at https://www.envoyproxy.io/docs/envoy/latest/api-docs/xds_protocol#how-the-client-specifies-what-resources-to-return
 	IsWildcard() bool
-
-	// WatchesResources returns whether at least one of the resources provided is currently being watched by the subscription.
-	// It is currently only applicable to delta-xds.
-	// If the request is wildcard, it will always return true,
-	// otherwise it will compare the provided resources to the list of resources currently subscribed
-	WatchesResources(resourceNames map[string]struct{}) bool
 }
 
 // ConfigWatcher requests watches for configuration resources by a node, last

--- a/pkg/server/stream/v3/subscription.go
+++ b/pkg/server/stream/v3/subscription.go
@@ -163,21 +163,6 @@ func (s Subscription) IsWildcard() bool {
 	return s.wildcard
 }
 
-// WatchesResources returns whether at least one of the resources provided is currently being watched by the subscription.
-// If the request is wildcard, it will always return true,
-// otherwise it will compare the provided resources to the list of resources currently subscribed
-func (s Subscription) WatchesResources(resourceNames map[string]struct{}) bool {
-	if s.wildcard {
-		return true
-	}
-	for resourceName := range resourceNames {
-		if _, ok := s.subscribedResourceNames[resourceName]; ok {
-			return true
-		}
-	}
-	return false
-}
-
 // ReturnedResources returns the list of resources returned to the client
 // and their version
 func (s Subscription) ReturnedResources() map[string]string {


### PR DESCRIPTION
PR #11 implements a change for stable version computation to avoid the first watch (always non-wildcard for endpoints) to trigger in-sync the entire stable version computation.

From our profiles, the vast majority of CPU used by our control-planes is spent on this serialization for version computation as:
- in linear cache, most watches won't be wildcards, as grpc-xds does not use wildcard and common use cases of linear caches like endpoint tracking also won't be
- in a model where the cache would have all CLA keys, or all cluster keys, it is likely only a subset is used on a given control-plane
In this context, using lazy computation of stable version should yield a very high gain (probably 90+% in our cases) while not worsening wildcard cases (as all versions will still be computed only once). It makes the code a bit more complex due to the need of bubbling up marshaling errors but imo this remains acceptable given the potential benefits. 
One drawback (but actually not great already) is that if a resource is inserted while there is no watch for it, and then watches request it, those watches will get rejected. Currently those watches would get partial results silently