### PR TITLE
[Linear cache] Increase mutualization between delta and sotw in linear cache to have behavior driven logic instead

### DIFF
--- a/pkg/cache/v3/delta.go
+++ b/pkg/cache/v3/delta.go
@@ -29,14 +29,14 @@ type resourceContainer struct {
 func createDeltaResponse(ctx context.Context, req *DeltaRequest, sub Subscription, resources resourceContainer, cacheVersion string) *RawDeltaResponse {
 	// variables to build our response with
 	var nextVersionMap map[string]string
-	var filtered []types.Resource
+	var filtered []types.ResourceWithTTL
 	var toRemove []string
 
 	// If we are handling a wildcard request, we want to respond with all resources
 	switch {
 	case sub.IsWildcard():
 		if len(sub.ReturnedResources()) == 0 {
-			filtered = make([]types.Resource, 0, len(resources.resourceMap))
+			filtered = make([]types.ResourceWithTTL, 0, len(resources.resourceMap))
 		}
 		nextVersionMap = make(map[string]string, len(resources.resourceMap))
 		for name, r := range resources.resourceMap {
@@ -46,7 +46,7 @@ func createDeltaResponse(ctx context.Context, req *DeltaRequest, sub Subscriptio
 			nextVersionMap[name] = version
 			prevVersion, found := sub.ReturnedResources()[name]
 			if !found || (prevVersion != version) {
-				filtered = append(filtered, r)
+				filtered = append(filtered, types.ResourceWithTTL{Resource: r})
 			}
 		}
 
@@ -66,7 +66,7 @@ func createDeltaResponse(ctx context.Context, req *DeltaRequest, sub Subscriptio
 			if r, ok := resources.resourceMap[name]; ok {
 				nextVersion := resources.versionMap[name]
 				if prevVersion != nextVersion {
-					filtered = append(filtered, r)
+					filtered = append(filtered, types.ResourceWithTTL{Resource: r})
 				}
 				nextVersionMap[name] = nextVersion
 			} else if found {

--- a/pkg/cache/v3/linear.go
+++ b/pkg/cache/v3/linear.go
@@ -69,17 +69,21 @@ func (c *cachedResource) getVersion(useStableVersion bool) (string, error) {
 }
 
 type watch interface {
-	// Only used for statistics
+	// isDelta indicates whether the watch is a delta one.
+	// It should not be used to take functional decisions, but is still currently used pending final changes.
+	// It can be used to generate statistics.
 	isDelta() bool
-	// If set, versions returneed in the response will be built using stable versions
-	// instead of cache update versions.
+	// useStableVersion indicates whether versions returned in the response are built using stable versions instead of cache update versions.
 	useStableVersion() bool
-	// If set, all currently existing resources matching the request will be returned in the response,
-	// even if not modified.
+	// sendFullStateResponses requires that all resources matching the request, with no regards to which ones actually updated, must be provided in the response.
+	// As a consequence, sending a response with no resources has a functional meaning of no matching resources available.
 	sendFullStateResponses() bool
 
 	getSubscription() Subscription
-	buildResponse(updatedResources []types.ResourceWithTTL, _ []string, returnedVersions map[string]string, version string) WatchResponse
+	// buildResponse computes the actual WatchResponse object to be sent on the watch.
+	buildResponse(updatedResources []types.ResourceWithTTL, removedResources []string, returnedVersions map[string]string, version string) WatchResponse
+	// sendResponse sends the response for the watch.
+	// It must be called at most once.
 	sendResponse(resp WatchResponse)
 }
 

--- a/pkg/cache/v3/linear.go
+++ b/pkg/cache/v3/linear.go
@@ -16,11 +16,8 @@ package cache
 
 import (
 	"context"
-	"encoding/hex"
 	"errors"
 	"fmt"
-	"hash/fnv"
-	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -71,22 +68,25 @@ func (c *cachedResource) getVersion(useStableVersion bool) (string, error) {
 	return c.getStableVersion()
 }
 
-type watches struct {
-	// sotw keeps track of current sotw watches, indexed per watch id.
-	sotw map[uint64]ResponseWatch
-	// delta keeps track of current delta watches, indexed per watch id.
-	delta map[uint64]DeltaResponseWatch
+type watch interface {
+	// Only used for statistics
+	isDelta() bool
+	// If set, versions returneed in the response will be built using stable versions
+	// instead of cache update versions.
+	useStableVersion() bool
+	// If set, all currently existing resources matching the request will be returned in the response,
+	// even if not modified.
+	sendFullStateResponses() bool
+
+	getSubscription() Subscription
+	buildResponse(updatedResources []types.ResourceWithTTL, _ []string, returnedVersions map[string]string, version string) WatchResponse
+	sendResponse(resp WatchResponse)
 }
+
+type watches map[uint64]watch
 
 func newWatches() watches {
-	return watches{
-		sotw:  make(map[uint64]ResponseWatch),
-		delta: make(map[uint64]DeltaResponseWatch),
-	}
-}
-
-func (w *watches) empty() bool {
-	return len(w.sotw)+len(w.delta) == 0
+	return make(watches)
 }
 
 // LinearCache supports collections of opaque resources. This cache has a
@@ -123,6 +123,8 @@ type LinearCache struct {
 	// is an hash of the returned versions to allow watch resumptions when reconnecting to the cache with a
 	// new subscription.
 	useStableVersionsInSotw bool
+
+	watchCount int
 
 	log log.Logger
 
@@ -198,22 +200,14 @@ func NewLinearCache(typeURL string, opts ...LinearCacheOption) *LinearCache {
 // computeResourceChange compares the subscription known resources and the cache current state to compute the list of resources
 // which have changed and should be notified to the user.
 //
-// The alwaysConsiderAllResources argument removes the consideration of the subscription known resources (e.g. if the version did not match),
-// and return all known subscribed resources.
-//
 // The useStableVersion argument defines what version type to use for resources:
 //   - if set to false versions are based on when resources were updated in the cache.
 //   - if set to true versions are a stable property of the resource, with no regard to when it was added to the cache.
-func (cache *LinearCache) computeResourceChange(sub Subscription, alwaysConsiderAllResources, useStableVersion bool) (updated, removed []string, err error) {
+func (cache *LinearCache) computeResourceChange(sub Subscription, useStableVersion bool) (updated, removed []string, err error) {
 	var changedResources []string
 	var removedResources []string
 
 	knownVersions := sub.ReturnedResources()
-	if alwaysConsiderAllResources {
-		// The response will include all resources, with no regards of resources potentially already returned.
-		knownVersions = make(map[string]string)
-	}
-
 	if sub.IsWildcard() {
 		for resourceName, resource := range cache.resources {
 			knownVersion, ok := knownVersions[resourceName]
@@ -280,38 +274,13 @@ func (cache *LinearCache) computeResourceChange(sub Subscription, alwaysConsider
 	return changedResources, removedResources, nil
 }
 
-func computeSotwStableVersion(versionMap map[string]string) string {
-	// To enforce a stable hash we need to have an ordered vision of the map.
-	keys := make([]string, 0, len(versionMap))
-	for key := range versionMap {
-		keys = append(keys, key)
-	}
-	sort.Strings(keys)
-
-	mapHasher := fnv.New64()
-
-	buffer := make([]byte, 0, 8)
-	itemHasher := fnv.New64()
-	for _, key := range keys {
-		buffer = buffer[:0]
-		itemHasher.Reset()
-		itemHasher.Write([]byte(key))
-		mapHasher.Write(itemHasher.Sum(buffer))
-		buffer = buffer[:0]
-		itemHasher.Reset()
-		itemHasher.Write([]byte(versionMap[key]))
-		mapHasher.Write(itemHasher.Sum(buffer))
-	}
-	buffer = buffer[:0]
-	return hex.EncodeToString(mapHasher.Sum(buffer))
-}
-
-func (cache *LinearCache) computeSotwResponse(watch ResponseWatch, alwaysConsiderAllResources bool) (*RawResponse, error) {
-	changedResources, removedResources, err := cache.computeResourceChange(watch.subscription, alwaysConsiderAllResources, cache.useStableVersionsInSotw)
+func (cache *LinearCache) computeResponse(watch watch, replyEvenIfEmpty bool) (WatchResponse, error) {
+	sub := watch.getSubscription()
+	changedResources, removedResources, err := cache.computeResourceChange(sub, watch.useStableVersion())
 	if err != nil {
 		return nil, err
 	}
-	if len(changedResources) == 0 && len(removedResources) == 0 && !alwaysConsiderAllResources {
+	if len(changedResources) == 0 && len(removedResources) == 0 && !replyEvenIfEmpty {
 		// Nothing changed.
 		return nil, nil
 	}
@@ -325,8 +294,9 @@ func (cache *LinearCache) computeSotwResponse(watch ResponseWatch, alwaysConside
 	switch {
 	// For lds and cds, answers will always include all existing subscribed resources, with no regard to which resource was changed or removed.
 	// For other types, the response only includes updated resources (sotw cannot notify for deletion).
-	case !ResourceRequiresFullStateInSotw(cache.typeURL):
-		if !alwaysConsiderAllResources && len(changedResources) == 0 {
+	case !watch.sendFullStateResponses():
+		// TODO(valerian-roche): remove this leak of delta/sotw behavior here.
+		if !watch.isDelta() && !replyEvenIfEmpty && len(changedResources) == 0 {
 			// If the request is not the initial one, and the type does not require full updates,
 			// do not return if nothing is to be set.
 			// For full-state resources an empty response does have a semantic meaning.
@@ -335,7 +305,7 @@ func (cache *LinearCache) computeSotwResponse(watch ResponseWatch, alwaysConside
 
 		// changedResources is already filtered based on the subscription.
 		resourcesToReturn = changedResources
-	case watch.subscription.IsWildcard():
+	case sub.IsWildcard():
 		// Include all resources for the type.
 		resourcesToReturn = make([]string, 0, len(cache.resources))
 		for resourceName := range cache.resources {
@@ -343,7 +313,7 @@ func (cache *LinearCache) computeSotwResponse(watch ResponseWatch, alwaysConside
 		}
 	default:
 		// Include all resources matching the subscription, with no concern on whether it has been updated or not.
-		requestedResources := watch.subscription.SubscribedResources()
+		requestedResources := sub.SubscribedResources()
 		// The linear cache could be very large (e.g. containing all potential CLAs)
 		// Therefore drives on the subscription requested resources.
 		resourcesToReturn = make([]string, 0, len(requestedResources))
@@ -355,9 +325,9 @@ func (cache *LinearCache) computeSotwResponse(watch ResponseWatch, alwaysConside
 	}
 
 	// returnedVersions includes all resources currently known to the subscription and their version.
-	returnedVersions := make(map[string]string, len(watch.subscription.ReturnedResources()))
+	returnedVersions := make(map[string]string, len(sub.ReturnedResources()))
 	// Clone the current returned versions. The cache should not alter the subscription.
-	for resourceName, version := range watch.subscription.ReturnedResources() {
+	for resourceName, version := range sub.ReturnedResources() {
 		returnedVersions[resourceName] = version
 	}
 
@@ -365,7 +335,7 @@ func (cache *LinearCache) computeSotwResponse(watch ResponseWatch, alwaysConside
 	for _, resourceName := range resourcesToReturn {
 		cachedResource := cache.resources[resourceName]
 		resources = append(resources, types.ResourceWithTTL{Resource: cachedResource.Resource})
-		version, err := cachedResource.getVersion(cache.useStableVersionsInSotw)
+		version, err := cachedResource.getVersion(watch.useStableVersion())
 		if err != nil {
 			return nil, fmt.Errorf("failed to compute version of %s: %w", resourceName, err)
 		}
@@ -378,131 +348,49 @@ func (cache *LinearCache) computeSotwResponse(watch ResponseWatch, alwaysConside
 		delete(returnedVersions, resourceName)
 	}
 
+	// TODO(valerian-roche): remove this leak of delta/sotw behavior here.
 	responseVersion := cache.getVersion()
-	if cache.useStableVersionsInSotw {
+	if watch.useStableVersion() && !watch.isDelta() {
 		responseVersion = cache.versionPrefix + computeSotwStableVersion(returnedVersions)
 	}
 
-	return &RawResponse{
-		Request:           watch.Request,
-		Resources:         resources,
-		ReturnedResources: returnedVersions,
-		Version:           responseVersion,
-		Ctx:               context.Background(),
-	}, nil
-}
-
-func (cache *LinearCache) computeDeltaResponse(watch DeltaResponseWatch) (*RawDeltaResponse, error) {
-	changedResources, removedResources, err := cache.computeResourceChange(watch.subscription, false, true)
-	if err != nil {
-		return nil, err
-	}
-
-	if len(changedResources) == 0 && len(removedResources) == 0 {
-		// Nothing changed.
-		return nil, nil
-	}
-
-	returnedVersions := make(map[string]string, len(watch.subscription.ReturnedResources()))
-	// Clone the current returned versions. The cache should not alter the subscription
-	for resourceName, version := range watch.subscription.ReturnedResources() {
-		returnedVersions[resourceName] = version
-	}
-
-	cacheVersion := cache.getVersion()
-	resources := make([]types.Resource, 0, len(changedResources))
-	for _, resourceName := range changedResources {
-		resource := cache.resources[resourceName]
-		resources = append(resources, resource.Resource)
-		version, err := resource.getStableVersion()
-		if err != nil {
-			return nil, fmt.Errorf("failed to compute stable version of %s: %w", resourceName, err)
-		}
-		returnedVersions[resourceName] = version
-	}
-	// Cleanup resources no longer existing in the cache or no longer subscribed.
-	for _, resourceName := range removedResources {
-		delete(returnedVersions, resourceName)
-	}
-
-	return &RawDeltaResponse{
-		DeltaRequest:      watch.Request,
-		Resources:         resources,
-		RemovedResources:  removedResources,
-		NextVersionMap:    returnedVersions,
-		SystemVersionInfo: cacheVersion,
-		Ctx:               context.Background(),
-	}, nil
+	return watch.buildResponse(resources, removedResources, returnedVersions, responseVersion), nil
 }
 
 func (cache *LinearCache) notifyAll(modified []string) error {
 	// Gather the list of watches impacted by the modified resources.
-	sotwWatches := make(map[uint64]ResponseWatch)
-	deltaWatches := make(map[uint64]DeltaResponseWatch)
+	resourceWatches := newWatches()
 	for _, name := range modified {
-		for watchID, watch := range cache.resourceWatches[name].sotw {
-			sotwWatches[watchID] = watch
-		}
-		for watchID, watch := range cache.resourceWatches[name].delta {
-			deltaWatches[watchID] = watch
+		for watchID, watch := range cache.resourceWatches[name] {
+			resourceWatches[watchID] = watch
 		}
 	}
 
-	// sotw watches
-	for watchID, watch := range sotwWatches {
-		response, err := cache.computeSotwResponse(watch, false)
+	for watchID, watch := range resourceWatches {
+		response, err := cache.computeResponse(watch, false)
 		if err != nil {
 			return err
 		}
 
 		if response != nil {
-			watch.Response <- response
-			cache.removeWatch(watchID, watch.subscription)
+			watch.sendResponse(response)
+			cache.removeWatch(watchID, watch.getSubscription())
 		} else {
 			cache.log.Infof("[Linear cache] Watch %d detected as triggered but no change was found", watchID)
 		}
 	}
 
-	for watchID, watch := range cache.wildcardWatches.sotw {
-		response, err := cache.computeSotwResponse(watch, false)
+	for watchID, watch := range cache.wildcardWatches {
+		response, err := cache.computeResponse(watch, false)
 		if err != nil {
 			return err
 		}
 
 		if response != nil {
-			watch.Response <- response
-			delete(cache.wildcardWatches.sotw, watchID)
+			watch.sendResponse(response)
+			cache.removeWildcardWatch(watchID)
 		} else {
 			cache.log.Infof("[Linear cache] Wildcard watch %d detected as triggered but no change was found", watchID)
-		}
-	}
-
-	// delta watches
-	for watchID, watch := range deltaWatches {
-		response, err := cache.computeDeltaResponse(watch)
-		if err != nil {
-			return err
-		}
-
-		if response != nil {
-			watch.Response <- response
-			cache.removeDeltaWatch(watchID, watch.subscription)
-		} else {
-			cache.log.Infof("[Linear cache] Delta watch %d detected as triggered but no change was found", watchID)
-		}
-	}
-
-	for watchID, watch := range cache.wildcardWatches.delta {
-		response, err := cache.computeDeltaResponse(watch)
-		if err != nil {
-			return err
-		}
-
-		if response != nil {
-			watch.Response <- response
-			delete(cache.wildcardWatches.delta, watchID)
-		} else {
-			cache.log.Infof("[Linear cache] Wildcard delta watch %d detected as triggered but no change was found", watchID)
 		}
 	}
 
@@ -612,10 +500,10 @@ func (cache *LinearCache) CreateWatch(request *Request, sub Subscription, value 
 
 	// If the request does not include a version the client considers it has no current state.
 	// In this case we will always reply to allow proper initialization of dependencies in the client.
-	ignoreCurrentSubscriptionResources := request.GetVersionInfo() == ""
+	replyEvenIfEmpty := request.GetVersionInfo() == ""
 	if !strings.HasPrefix(request.GetVersionInfo(), cache.versionPrefix) {
 		// If the version of the request does not match the cache prefix, we will send a response in all cases to match the legacy behavior.
-		ignoreCurrentSubscriptionResources = true
+		replyEvenIfEmpty = true
 		cache.log.Debugf("[linear cache] received watch with version %s not matching the cache prefix %s. Will return all known resources", request.GetVersionInfo(), cache.versionPrefix)
 	}
 
@@ -630,12 +518,18 @@ func (cache *LinearCache) CreateWatch(request *Request, sub Subscription, value 
 	// For now it is not done as:
 	//  - for the first case, while the protocol documentation does not explicitly mention the case, it does not mark it impossible and explicitly references unsubscribing from wildcard.
 	//  - for the second one we could likely do it with little difficulty if need be, but if users rely on the current monotonic version it could impact their callbacks implementations.
-	watch := ResponseWatch{Request: request, Response: value, subscription: sub}
+	watch := ResponseWatch{
+		Request:             request,
+		Response:            value,
+		subscription:        sub,
+		enableStableVersion: cache.useStableVersionsInSotw,
+		fullStateResponses:  ResourceRequiresFullStateInSotw(cache.typeURL),
+	}
 
 	cache.mu.Lock()
 	defer cache.mu.Unlock()
 
-	response, err := cache.computeSotwResponse(watch, ignoreCurrentSubscriptionResources)
+	response, err := cache.computeResponse(watch, replyEvenIfEmpty)
 	if err != nil {
 		return nil, fmt.Errorf("failed to compute the watch respnse: %w", err)
 	}
@@ -646,14 +540,17 @@ func (cache *LinearCache) CreateWatch(request *Request, sub Subscription, value 
 		//  - provides a non-empty version, matching the version prefix
 		// and the cache uses stable versions, if the generated versions are the same as the previous one, we do not return the response.
 		// This avoids resending all data if the new subscription is just a resumption of the previous one.
-		if cache.useStableVersionsInSotw && request.GetResponseNonce() == "" && !ignoreCurrentSubscriptionResources {
-			shouldReply = request.GetVersionInfo() != response.Version
-
-			// We confirmed the content of the known resources, store them in the watch we create.
-			subscription := newWatchSubscription(sub)
-			subscription.returnedResources = response.ReturnedResources
-			watch.subscription = subscription
-			sub = subscription
+		if cache.useStableVersionsInSotw && request.GetResponseNonce() == "" && !replyEvenIfEmpty {
+			if request.GetVersionInfo() != response.GetResponseVersion() {
+				// The response has a different returned version map as the request
+				shouldReply = true
+			} else {
+				// We confirmed the content of the known resources, store them in the watch we create.
+				subscription := newWatchSubscription(sub)
+				subscription.returnedResources = response.GetReturnedResources()
+				watch.subscription = subscription
+				sub = subscription
+			}
 		} else {
 			shouldReply = true
 		}
@@ -661,49 +558,11 @@ func (cache *LinearCache) CreateWatch(request *Request, sub Subscription, value 
 
 	if shouldReply {
 		cache.log.Debugf("[linear cache] replying to the watch with resources %v (subscription values %v, known %v)", response.GetReturnedResources(), sub.SubscribedResources(), sub.ReturnedResources())
-		watch.Response <- response
+		watch.sendResponse(response)
 		return func() {}, nil
 	}
 
-	watchID := cache.nextWatchID()
-	// Create open watches since versions are up to date.
-	if sub.IsWildcard() {
-		cache.log.Infof("[linear cache] open watch %d for %s all resources, known versions %v, system version %q", watchID, cache.typeURL, sub.ReturnedResources(), cache.getVersion())
-		cache.wildcardWatches.sotw[watchID] = watch
-		return func() {
-			cache.mu.Lock()
-			defer cache.mu.Unlock()
-			delete(cache.wildcardWatches.sotw, watchID)
-		}, nil
-	}
-
-	cache.log.Infof("[linear cache] open watch %d for %s resources %v, known versions %v, system version %q", watchID, cache.typeURL, sub.SubscribedResources(), sub.ReturnedResources(), cache.getVersion())
-	for name := range sub.SubscribedResources() {
-		watches, exists := cache.resourceWatches[name]
-		if !exists {
-			watches = newWatches()
-			cache.resourceWatches[name] = watches
-		}
-		watches.sotw[watchID] = watch
-	}
-	return func() {
-		cache.mu.Lock()
-		defer cache.mu.Unlock()
-		cache.removeWatch(watchID, watch.subscription)
-	}, nil
-}
-
-// Must be called under lock
-func (cache *LinearCache) removeWatch(watchID uint64, sub Subscription) {
-	// Make sure we clean the watch for ALL resources it might be associated with,
-	// as the channel will no longer be listened to
-	for resource := range sub.SubscribedResources() {
-		resourceWatches := cache.resourceWatches[resource]
-		delete(resourceWatches.sotw, watchID)
-		if resourceWatches.empty() {
-			delete(cache.resourceWatches, resource)
-		}
-	}
+	return cache.trackWatch(watch), nil
 }
 
 func (cache *LinearCache) CreateDeltaWatch(request *DeltaRequest, sub Subscription, value chan DeltaResponse) (func(), error) {
@@ -716,60 +575,17 @@ func (cache *LinearCache) CreateDeltaWatch(request *DeltaRequest, sub Subscripti
 	cache.mu.Lock()
 	defer cache.mu.Unlock()
 
-	response, err := cache.computeDeltaResponse(watch)
+	response, err := cache.computeResponse(watch, false)
 	if err != nil {
 		return nil, fmt.Errorf("failed to compute the watch respnse: %w", err)
 	}
-
 	if response != nil {
 		cache.log.Debugf("[linear cache] replying to the delta watch (subscription values %v, known %v)", sub.SubscribedResources(), sub.ReturnedResources())
-		watch.Response <- response
+		watch.sendResponse(response)
 		return nil, nil
 	}
 
-	watchID := cache.nextWatchID()
-	// Create open watches since versions are up to date.
-	if sub.IsWildcard() {
-		cache.log.Infof("[linear cache] open delta watch %d for all %s resources, system version %q", watchID, cache.typeURL, cache.getVersion())
-		cache.wildcardWatches.delta[watchID] = watch
-		return func() {
-			cache.mu.Lock()
-			defer cache.mu.Unlock()
-			delete(cache.wildcardWatches.delta, watchID)
-		}, nil
-	}
-
-	cache.log.Infof("[linear cache] open delta watch %d for %s resources %v, system version %q", watchID, cache.typeURL, sub.SubscribedResources(), cache.getVersion())
-	for name := range sub.SubscribedResources() {
-		watches, exists := cache.resourceWatches[name]
-		if !exists {
-			watches = newWatches()
-			cache.resourceWatches[name] = watches
-		}
-		watches.delta[watchID] = watch
-	}
-	return func() {
-		cache.mu.Lock()
-		defer cache.mu.Unlock()
-		cache.removeDeltaWatch(watchID, watch.subscription)
-	}, nil
-}
-
-func (cache *LinearCache) getVersion() string {
-	return cache.versionPrefix + strconv.FormatUint(cache.version, 10)
-}
-
-// cancellation function for cleaning stale watches
-func (cache *LinearCache) removeDeltaWatch(watchID uint64, sub Subscription) {
-	// Make sure we clean the watch for ALL resources it might be associated with,
-	// as the channel will no longer be listened to
-	for resource := range sub.SubscribedResources() {
-		resourceWatches := cache.resourceWatches[resource]
-		delete(resourceWatches.delta, watchID)
-		if resourceWatches.empty() {
-			delete(cache.resourceWatches, resource)
-		}
-	}
+	return cache.trackWatch(watch), nil
 }
 
 func (cache *LinearCache) nextWatchID() uint64 {
@@ -778,6 +594,65 @@ func (cache *LinearCache) nextWatchID() uint64 {
 		panic("watch id count overflow")
 	}
 	return cache.currentWatchID
+}
+
+// Must be called under lock
+func (cache *LinearCache) trackWatch(watch watch) func() {
+	cache.watchCount++
+
+	watchID := cache.nextWatchID()
+	sub := watch.getSubscription()
+	// Create open watches since versions are up to date.
+	if sub.IsWildcard() {
+		cache.log.Infof("[linear cache] open watch %d for %s all resources", watchID, cache.typeURL)
+		cache.log.Debugf("[linear cache] subscription details for watch %d: known versions %v, system version %q", watchID, sub.ReturnedResources(), cache.getVersion())
+		cache.wildcardWatches[watchID] = watch
+		return func() {
+			cache.mu.Lock()
+			defer cache.mu.Unlock()
+			cache.removeWildcardWatch(watchID)
+		}
+	}
+
+	cache.log.Infof("[linear cache] open watch %d for %s resources %v", watchID, cache.typeURL, sub.SubscribedResources())
+	cache.log.Debugf("[linear cache] subscription details for watch %d: known versions %v, system version %q", watchID, sub.ReturnedResources(), cache.getVersion())
+	for name := range sub.SubscribedResources() {
+		watches, exists := cache.resourceWatches[name]
+		if !exists {
+			watches = newWatches()
+			cache.resourceWatches[name] = watches
+		}
+		watches[watchID] = watch
+	}
+	return func() {
+		cache.mu.Lock()
+		defer cache.mu.Unlock()
+		cache.removeWatch(watchID, sub)
+	}
+}
+
+// Must be called under lock
+func (cache *LinearCache) removeWatch(watchID uint64, sub Subscription) {
+	// Make sure we clean the watch for ALL resources it might be associated with,
+	// as the channel will no longer be listened to
+	for resource := range sub.SubscribedResources() {
+		resourceWatches := cache.resourceWatches[resource]
+		delete(resourceWatches, watchID)
+		if len(resourceWatches) == 0 {
+			delete(cache.resourceWatches, resource)
+		}
+	}
+	cache.watchCount--
+}
+
+// Must be called under lock
+func (cache *LinearCache) removeWildcardWatch(watchID uint64) {
+	cache.watchCount--
+	delete(cache.wildcardWatches, watchID)
+}
+
+func (cache *LinearCache) getVersion() string {
+	return cache.versionPrefix + strconv.FormatUint(cache.version, 10)
 }
 
 func (cache *LinearCache) Fetch(context.Context, *Request) (Response, error) {
@@ -792,30 +667,23 @@ func (cache *LinearCache) NumResources() int {
 	return len(cache.resources)
 }
 
-// NumWatches returns the number of active sotw watches for a resource name.
+// NumWatches returns the number of active watches for a resource name.
 func (cache *LinearCache) NumWatches(name string) int {
 	cache.mu.RLock()
 	defer cache.mu.RUnlock()
-	return len(cache.resourceWatches[name].sotw) + len(cache.wildcardWatches.sotw)
+	return len(cache.resourceWatches[name]) + len(cache.wildcardWatches)
 }
 
-// NumDeltaWatchesForResource returns the number of active delta watches for a resource name.
-func (cache *LinearCache) NumDeltaWatchesForResource(name string) int {
+// TotalWatches returns the number of active watches on the cache in general.
+func (cache *LinearCache) NumWildcardWatches() int {
 	cache.mu.RLock()
 	defer cache.mu.RUnlock()
-	return len(cache.resourceWatches[name].delta) + len(cache.wildcardWatches.delta)
+	return len(cache.wildcardWatches)
 }
 
-// NumDeltaWatches returns the total number of active delta watches.
-// Warning: it is quite inefficient, and NumDeltaWatchesForResource should be preferred.
-func (cache *LinearCache) NumDeltaWatches() int {
+// NumCacheWatches returns the number of active watches on the cache in general.
+func (cache *LinearCache) NumCacheWatches() int {
 	cache.mu.RLock()
 	defer cache.mu.RUnlock()
-	uniqueWatches := map[uint64]struct{}{}
-	for _, watches := range cache.resourceWatches {
-		for id := range watches.delta {
-			uniqueWatches[id] = struct{}{}
-		}
-	}
-	return len(uniqueWatches) + len(cache.wildcardWatches.delta)
+	return cache.watchCount
 }

--- a/pkg/cache/v3/resource.go
+++ b/pkg/cache/v3/resource.go
@@ -116,10 +116,10 @@ func ResourceRequiresFullStateInSotw(typeURL resource.Type) bool {
 }
 
 // GetResourceName returns the resource names for a list of valid xDS response types.
-func GetResourceNames(resources []types.Resource) []string {
+func GetResourceNames(resources []types.ResourceWithTTL) []string {
 	out := make([]string, len(resources))
 	for i, r := range resources {
-		out[i] = GetResourceName(r)
+		out[i] = GetResourceName(r.Resource)
 	}
 	return out
 }

--- a/pkg/cache/v3/resource_test.go
+++ b/pkg/cache/v3/resource_test.go
@@ -127,17 +127,17 @@ func TestGetResourceName(t *testing.T) {
 func TestGetResourceNames(t *testing.T) {
 	tests := []struct {
 		name  string
-		input []types.Resource
+		input []types.ResourceWithTTL
 		want  []string
 	}{
 		{
 			name:  "empty",
-			input: []types.Resource{},
+			input: []types.ResourceWithTTL{},
 			want:  []string{},
 		},
 		{
 			name:  "many",
-			input: []types.Resource{testRuntime, testListener, testVirtualHost},
+			input: []types.ResourceWithTTL{{Resource: testRuntime}, {Resource: testListener}, {Resource: testVirtualHost}},
 			want:  []string{runtimeName, listenerName, virtualHostName},
 		},
 	}

--- a/pkg/cache/v3/simple.go
+++ b/pkg/cache/v3/simple.go
@@ -411,7 +411,7 @@ func (cache *snapshotCache) CreateWatch(request *Request, sub Subscription, valu
 		return cache.cancelWatch(nodeID, watchID)
 	}
 
-	watch := ResponseWatch{Request: request, Response: value, subscription: sub}
+	watch := ResponseWatch{Request: request, Response: value, subscription: sub, fullStateResponses: ResourceRequiresFullStateInSotw(request.GetTypeUrl())}
 
 	snapshot, exists := cache.snapshots[nodeID]
 	if !exists {

--- a/pkg/cache/v3/status.go
+++ b/pkg/cache/v3/status.go
@@ -15,11 +15,15 @@
 package cache
 
 import (
+	"context"
+	"encoding/hex"
+	"hash/fnv"
 	"sort"
 	"sync"
 	"time"
 
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
 )
 
 // NodeHash computes string identifiers for Envoy nodes.
@@ -83,6 +87,37 @@ type statusInfo struct {
 	mu sync.RWMutex
 }
 
+func computeSotwStableVersion(versionMap map[string]string) string {
+	// To enforce a stable hash we need to have an ordered vision of the map.
+	keys := make([]string, 0, len(versionMap))
+	for key := range versionMap {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	mapHasher := fnv.New64()
+
+	buffer := make([]byte, 0, 8)
+	itemHasher := fnv.New64()
+	for _, key := range keys {
+		buffer = buffer[:0]
+		itemHasher.Reset()
+		itemHasher.Write([]byte(key))
+		mapHasher.Write(itemHasher.Sum(buffer))
+		buffer = buffer[:0]
+		itemHasher.Reset()
+		itemHasher.Write([]byte(versionMap[key]))
+		mapHasher.Write(itemHasher.Sum(buffer))
+	}
+	buffer = buffer[:0]
+	return hex.EncodeToString(mapHasher.Sum(buffer))
+}
+
+type WatchResponse interface {
+	GetReturnedResources() map[string]string
+	GetResponseVersion() string
+}
+
 // ResponseWatch is a watch record keeping both the request and an open channel for the response.
 type ResponseWatch struct {
 	// Request is the original request for the watch.
@@ -93,6 +128,40 @@ type ResponseWatch struct {
 
 	// Subscription stores the current client subscription state.
 	subscription Subscription
+
+	enableStableVersion bool
+
+	fullStateResponses bool
+}
+
+func (w ResponseWatch) isDelta() bool {
+	return false
+}
+
+func (w ResponseWatch) buildResponse(updatedResources []types.ResourceWithTTL, _ []string, returnedVersions map[string]string, version string) WatchResponse {
+	return &RawResponse{
+		Request:           w.Request,
+		Resources:         updatedResources,
+		ReturnedResources: returnedVersions,
+		Version:           version,
+		Ctx:               context.Background(),
+	}
+}
+
+func (w ResponseWatch) useStableVersion() bool {
+	return w.enableStableVersion
+}
+
+func (w ResponseWatch) sendFullStateResponses() bool {
+	return w.fullStateResponses
+}
+
+func (w ResponseWatch) getSubscription() Subscription {
+	return w.subscription
+}
+
+func (w ResponseWatch) sendResponse(resp WatchResponse) {
+	w.Response <- resp.(*RawResponse)
 }
 
 // DeltaResponseWatch is a watch record keeping both the delta request and an open channel for the delta response.
@@ -105,6 +174,37 @@ type DeltaResponseWatch struct {
 
 	// Subscription stores the current client subscription state.
 	subscription Subscription
+}
+
+func (w DeltaResponseWatch) isDelta() bool {
+	return true
+}
+
+func (w DeltaResponseWatch) useStableVersion() bool {
+	return true
+}
+
+func (w DeltaResponseWatch) sendFullStateResponses() bool {
+	return false
+}
+
+func (w DeltaResponseWatch) getSubscription() Subscription {
+	return w.subscription
+}
+
+func (w DeltaResponseWatch) buildResponse(updatedResources []types.ResourceWithTTL, removedResources []string, returnedVersions map[string]string, version string) WatchResponse {
+	return &RawDeltaResponse{
+		DeltaRequest:      w.Request,
+		Resources:         updatedResources,
+		RemovedResources:  removedResources,
+		NextVersionMap:    returnedVersions,
+		SystemVersionInfo: version,
+		Ctx:               context.Background(),
+	}
+}
+
+func (w DeltaResponseWatch) sendResponse(resp WatchResponse) {
+	w.Response <- resp.(*RawDeltaResponse)
 }
 
 // newStatusInfo initializes a status info data structure.

--- a/pkg/cache/v3/status.go
+++ b/pkg/cache/v3/status.go
@@ -97,20 +97,16 @@ func computeSotwStableVersion(versionMap map[string]string) string {
 
 	mapHasher := fnv.New64()
 
-	buffer := make([]byte, 0, 8)
 	itemHasher := fnv.New64()
 	for _, key := range keys {
-		buffer = buffer[:0]
 		itemHasher.Reset()
 		itemHasher.Write([]byte(key))
-		mapHasher.Write(itemHasher.Sum(buffer))
-		buffer = buffer[:0]
+		mapHasher.Write(itemHasher.Sum(nil))
 		itemHasher.Reset()
 		itemHasher.Write([]byte(versionMap[key]))
-		mapHasher.Write(itemHasher.Sum(buffer))
+		mapHasher.Write(itemHasher.Sum(nil))
 	}
-	buffer = buffer[:0]
-	return hex.EncodeToString(mapHasher.Sum(buffer))
+	return hex.EncodeToString(mapHasher.Sum(nil))
 }
 
 type WatchResponse interface {
@@ -129,8 +125,10 @@ type ResponseWatch struct {
 	// Subscription stores the current client subscription state.
 	subscription Subscription
 
+	// enableStableVersion indicates whether versions returned in the response are built using stable versions instead of cache update versions.
 	enableStableVersion bool
 
+	// fullStateResponses requires that all resources matching the request, with no regards to which ones actually updated, must be provided in the response.
 	fullStateResponses bool
 }
 

--- a/pkg/server/v3/delta_test.go
+++ b/pkg/server/v3/delta_test.go
@@ -31,14 +31,14 @@ func (config *mockConfigWatcher) CreateDeltaWatch(req *discovery.DeltaDiscoveryR
 		versionMap[name] = cache.HashResource(marshaledResource)
 	}
 	var nextVersionMap map[string]string
-	var filtered []types.Resource
+	var filtered []types.ResourceWithTTL
 	var toRemove []string
 
 	// If we are handling a wildcard request, we want to respond with all resources
 	switch {
 	case sub.IsWildcard():
 		if len(sub.ReturnedResources()) == 0 {
-			filtered = make([]types.Resource, 0, len(resourceMap))
+			filtered = make([]types.ResourceWithTTL, 0, len(resourceMap))
 		}
 		nextVersionMap = make(map[string]string, len(resourceMap))
 		for name, r := range resourceMap {
@@ -48,7 +48,7 @@ func (config *mockConfigWatcher) CreateDeltaWatch(req *discovery.DeltaDiscoveryR
 			nextVersionMap[name] = version
 			prevVersion, found := sub.ReturnedResources()[name]
 			if !found || (prevVersion != version) {
-				filtered = append(filtered, r)
+				filtered = append(filtered, types.ResourceWithTTL{Resource: r})
 			}
 		}
 
@@ -67,7 +67,7 @@ func (config *mockConfigWatcher) CreateDeltaWatch(req *discovery.DeltaDiscoveryR
 			if r, ok := resourceMap[name]; ok {
 				nextVersion := versionMap[name]
 				if prevVersion != nextVersion {
-					filtered = append(filtered, r)
+					filtered = append(filtered, types.ResourceWithTTL{Resource: r})
 				}
 				nextVersionMap[name] = nextVersion
 			} else if found {


### PR DESCRIPTION
Following the addition of stable version support in sotw, the remaining differences of behavior between sotw and delta are:
 - on first request, check the returned version in sotw if activating stable version. Also compute the version differently
 - in some cases, return full state in sotw. In other case don't return if the only change is deletion
 - compute the version differently

In this context, the code can now be mostly merged, apart from the type differences on requests and responses (which I think can be reduced to none soon, but requires more rework on simple side and would be somewhat backward incompatible). 
In this PR, the linear cache no longer treats sotw and delta watches differently. They are tracked in the same maps and the changes and responses are computed in a common method. Differences in behavior (e.g. full state or which version to use) is now a functional attribute of the watch itself. 
There are two main parts not yet fully merged:
 - changing the version in sotw when using stable versions. The requirement to prepend cache version prefix makes it harder to abstract
 - defining whether a change only removing resources should trigger a response. This could be made a functional flag but given its intersection with `fullStateResponses` seemed fragile