### PR TITLE
[cleanup] Fix lint issues with new versions of golangci-lint

### DIFF
--- a/internal/example/resource.go
+++ b/internal/example/resource.go
@@ -77,7 +77,7 @@ func makeEndpoint(clusterName string) *endpoint.ClusterLoadAssignment {
 	}
 }
 
-func makeRoute(routeName string, clusterName string) *route.RouteConfiguration {
+func makeRoute(routeName, clusterName string) *route.RouteConfiguration {
 	return &route.RouteConfiguration{
 		Name: routeName,
 		VirtualHosts: []*route.VirtualHost{{
@@ -104,7 +104,7 @@ func makeRoute(routeName string, clusterName string) *route.RouteConfiguration {
 	}
 }
 
-func makeHTTPListener(listenerName string, route string) *listener.Listener {
+func makeHTTPListener(listenerName, route string) *listener.Listener {
 	routerConfig, _ := anypb.New(&router.Router{})
 	// HTTP filter configuration
 	manager := &hcm.HttpConnectionManager{

--- a/internal/upstream/main.go
+++ b/internal/upstream/main.go
@@ -32,7 +32,7 @@ func main() {
 	flag.Parse()
 
 	log.Printf("upstream listening HTTP/1.1 on %d\n", upstreamPort)
-	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+	http.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
 		if _, err := w.Write([]byte(hello)); err != nil {
 			log.Println(err)
 		}

--- a/pkg/cache/v3/linear_test.go
+++ b/pkg/cache/v3/linear_test.go
@@ -917,7 +917,7 @@ func TestLinearDeltaMultiResourceUpdates(t *testing.T) {
 	err = c.UpdateResources(map[string]types.Resource{"b": b, "d": d}, nil)
 	require.NoError(t, err)
 	verifyDeltaResponse(t, w, []resourceInfo{{"b", hashB}, {"d", hashD}}, nil)
-	// d is now watched and shoudl be returned
+	// d is now watched and should be returned
 	checkStableVersionsAreComputed(t, c, "b", "d")
 	assert.Equal(t, 3, c.NumResources())
 

--- a/pkg/server/v3/delta_test.go
+++ b/pkg/server/v3/delta_test.go
@@ -438,7 +438,7 @@ func TestDeltaCallbackError(t *testing.T) {
 			config.deltaResources = makeDeltaResources()
 
 			s := server.NewServer(context.Background(), config, server.CallbackFuncs{
-				DeltaStreamOpenFunc: func(ctx context.Context, i int64, s string) error {
+				DeltaStreamOpenFunc: func(context.Context, int64, string) error {
 					return errors.New("stream open error")
 				},
 			})

--- a/pkg/server/v3/server_test.go
+++ b/pkg/server/v3/server_test.go
@@ -373,20 +373,20 @@ func TestFetch(t *testing.T) {
 	callbackError := false
 
 	cb := server.CallbackFuncs{
-		StreamOpenFunc: func(ctx context.Context, i int64, s string) error {
+		StreamOpenFunc: func(context.Context, int64, string) error {
 			if callbackError {
 				return errors.New("stream open error")
 			}
 			return nil
 		},
-		FetchRequestFunc: func(ctx context.Context, request *discovery.DiscoveryRequest) error {
+		FetchRequestFunc: func(context.Context, *discovery.DiscoveryRequest) error {
 			if callbackError {
 				return errors.New("fetch request error")
 			}
 			requestCount++
 			return nil
 		},
-		FetchResponseFunc: func(request *discovery.DiscoveryRequest, response *discovery.DiscoveryResponse) {
+		FetchResponseFunc: func(*discovery.DiscoveryRequest, *discovery.DiscoveryResponse) {
 			responseCount++
 		},
 	}
@@ -668,7 +668,7 @@ func TestCallbackError(t *testing.T) {
 			config.responses = makeResponses()
 
 			s := server.NewServer(context.Background(), config, server.CallbackFuncs{
-				StreamOpenFunc: func(ctx context.Context, i int64, s string) error {
+				StreamOpenFunc: func(context.Context, int64, string) error {
 					return errors.New("stream open error")
 				},
 			})

--- a/pkg/test/main/main.go
+++ b/pkg/test/main/main.go
@@ -261,7 +261,6 @@ func main() {
 				if err := eds.UpdateResource(name, res); err != nil {
 					log.Printf("update error %q for %+v\n", err, name)
 					os.Exit(1)
-
 				}
 			}
 		}

--- a/pkg/test/resource/v3/resource.go
+++ b/pkg/test/resource/v3/resource.go
@@ -95,7 +95,7 @@ func MakeEndpoint(clusterName string, port uint32) *endpoint.ClusterLoadAssignme
 }
 
 // MakeCluster creates a cluster using either ADS or EDS.
-func MakeCluster(mode string, clusterName string) *cluster.Cluster {
+func MakeCluster(mode, clusterName string) *cluster.Cluster {
 	edsSource := configSource(mode)
 
 	connectTimeout := 5 * time.Second
@@ -109,7 +109,7 @@ func MakeCluster(mode string, clusterName string) *cluster.Cluster {
 	}
 }
 
-func MakeVHDSRouteConfig(mode string, routeName string) *route.RouteConfiguration {
+func MakeVHDSRouteConfig(mode, routeName string) *route.RouteConfiguration {
 	return &route.RouteConfiguration{
 		Name: routeName,
 		Vhds: &route.Vhds{
@@ -119,7 +119,7 @@ func MakeVHDSRouteConfig(mode string, routeName string) *route.RouteConfiguratio
 }
 
 // MakeRouteConfig creates an HTTP route config that routes to a given cluster.
-func MakeRouteConfig(routeName string, clusterName string) *route.RouteConfiguration {
+func MakeRouteConfig(routeName, clusterName string) *route.RouteConfiguration {
 	return &route.RouteConfiguration{
 		Name: routeName,
 		VirtualHosts: []*route.VirtualHost{{
@@ -144,7 +144,7 @@ func MakeRouteConfig(routeName string, clusterName string) *route.RouteConfigura
 }
 
 // MakeScopedRouteConfig creates an HTTP scoped route that routes to a given cluster.
-func MakeScopedRouteConfig(scopedRouteName string, routeConfigurationName string, keyFragments []string) *route.ScopedRouteConfiguration {
+func MakeScopedRouteConfig(scopedRouteName, routeConfigurationName string, keyFragments []string) *route.ScopedRouteConfiguration {
 	k := &route.ScopedRouteConfiguration_Key{}
 
 	for _, key := range keyFragments {
@@ -164,7 +164,7 @@ func MakeScopedRouteConfig(scopedRouteName string, routeConfigurationName string
 	}
 }
 
-func MakeVirtualHost(virtualHostName string, clusterName string) *route.VirtualHost {
+func MakeVirtualHost(virtualHostName, clusterName string) *route.VirtualHost {
 	ret := &route.VirtualHost{
 		Name:    virtualHostName,
 		Domains: []string{"*"},
@@ -297,7 +297,7 @@ func makeListener(listenerName string, port uint32, filterChains []*listener.Fil
 	}
 }
 
-func MakeRouteHTTPListener(mode string, listenerName string, port uint32, route string) *listener.Listener {
+func MakeRouteHTTPListener(mode, listenerName string, port uint32, route string) *listener.Listener {
 	rdsSource := configSource(mode)
 	routeSpecifier := &hcm.HttpConnectionManager_Rds{
 		Rds: &hcm.Rds{
@@ -331,7 +331,7 @@ func MakeRouteHTTPListener(mode string, listenerName string, port uint32, route 
 }
 
 // Creates a HTTP listener using Scoped Routes, which extracts the "Host" header field as the key.
-func MakeScopedRouteHTTPListener(mode string, listenerName string, port uint32) *listener.Listener {
+func MakeScopedRouteHTTPListener(mode, listenerName string, port uint32) *listener.Listener {
 	source := configSource(mode)
 	routeSpecifier := &hcm.HttpConnectionManager_ScopedRoutes{
 		ScopedRoutes: &hcm.ScopedRoutes{
@@ -386,7 +386,7 @@ func MakeScopedRouteHTTPListener(mode string, listenerName string, port uint32) 
 // MakeScopedRouteHTTPListenerForRoute is the same as
 // MakeScopedRouteHTTPListener, except it inlines a reference to the
 // routeConfigName, and so doesn't require a ScopedRouteConfiguration resource.
-func MakeScopedRouteHTTPListenerForRoute(mode string, listenerName string, port uint32, routeConfigName string) *listener.Listener {
+func MakeScopedRouteHTTPListenerForRoute(mode, listenerName string, port uint32, routeConfigName string) *listener.Listener {
 	source := configSource(mode)
 	routeSpecifier := &hcm.HttpConnectionManager_ScopedRoutes{
 		ScopedRoutes: &hcm.ScopedRoutes{
@@ -488,7 +488,7 @@ func MakeRuntime(runtimeName string) *runtime.Runtime {
 }
 
 // MakeExtensionConfig creates a extension config for a cluster.
-func MakeExtensionConfig(mode string, extensionConfigName string, route string) *core.TypedExtensionConfig {
+func MakeExtensionConfig(mode, extensionConfigName, route string) *core.TypedExtensionConfig {
 	rdsSource := configSource(mode)
 
 	// HTTP filter configuration


### PR DESCRIPTION
The version of golangci-lint was modified on GitHub and now fails on the head, flagging all our commits with a failed "push" lint job