### PR TITLE
No longer serialize the resource again per client when it is computed beforehand (delta or stable sotw)

### DIFF
--- a/pkg/cache/v3/cache_test.go
+++ b/pkg/cache/v3/cache_test.go
@@ -1,4 +1,4 @@
-package cache_test
+package cache
 
 import (
 	"testing"
@@ -12,7 +12,6 @@ import (
 	route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
-	"github.com/envoyproxy/go-control-plane/pkg/cache/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/resource/v3"
 )
 
@@ -21,8 +20,13 @@ const (
 )
 
 func TestResponseGetDiscoveryResponse(t *testing.T) {
-	routes := []types.ResourceWithTTL{{Resource: &route.RouteConfiguration{Name: resourceName}}}
-	resp := cache.RawResponse{
+	routes := []returnedResource{{
+		name: resourceName,
+		ResourceWithTTL: types.ResourceWithTTL{
+			Resource: &route.RouteConfiguration{Name: resourceName},
+		},
+	}}
+	resp := RawResponse{
 		Request:   &discovery.DiscoveryRequest{TypeUrl: resource.RouteType},
 		Version:   "v",
 		Resources: routes,
@@ -52,7 +56,7 @@ func TestPassthroughResponseGetDiscoveryResponse(t *testing.T) {
 		Resources:   []*anypb.Any{rsrc},
 		VersionInfo: "v",
 	}
-	resp := cache.PassthroughResponse{
+	resp := PassthroughResponse{
 		Request:           &discovery.DiscoveryRequest{TypeUrl: resource.RouteType},
 		DiscoveryResponse: dr,
 	}
@@ -70,8 +74,13 @@ func TestPassthroughResponseGetDiscoveryResponse(t *testing.T) {
 }
 
 func TestHeartbeatResponseGetDiscoveryResponse(t *testing.T) {
-	routes := []types.ResourceWithTTL{{Resource: &route.RouteConfiguration{Name: resourceName}}}
-	resp := cache.RawResponse{
+	routes := []returnedResource{{
+		name: resourceName,
+		ResourceWithTTL: types.ResourceWithTTL{
+			Resource: &route.RouteConfiguration{Name: resourceName},
+		},
+	}}
+	resp := RawResponse{
 		Request:   &discovery.DiscoveryRequest{TypeUrl: resource.RouteType},
 		Version:   "v",
 		Resources: routes,

--- a/pkg/cache/v3/delta_test.go
+++ b/pkg/cache/v3/delta_test.go
@@ -57,7 +57,7 @@ func TestSnapshotCacheDeltaWatch(t *testing.T) {
 			select {
 			case out := <-watches[typ]:
 				snapshot := fixture.snapshot()
-				assertResourceMapEqual(t, cache.IndexResourcesByName(out.(*cache.RawDeltaResponse).Resources), snapshot.GetResourcesAndTTL(typ))
+				assertResourceMapEqual(t, cache.IndexReturnedResourcesByName(out.(*cache.RawDeltaResponse).Resources), snapshot.GetResourcesAndTTL(typ))
 				sub := subscriptions[typ]
 				sub.SetReturnedResources(out.GetNextVersionMap())
 				subscriptions[typ] = sub
@@ -109,7 +109,7 @@ func TestSnapshotCacheDeltaWatch(t *testing.T) {
 	case out := <-watches[testTypes[0]]:
 		snapshot2 := fixture.snapshot()
 		snapshot2.Resources[types.Endpoint] = cache.NewResources(fixture.version2, []types.Resource{resource.MakeEndpoint(clusterName, 9090)})
-		assertResourceMapEqual(t, cache.IndexResourcesByName(out.(*cache.RawDeltaResponse).Resources), snapshot2.GetResourcesAndTTL(rsrc.EndpointType))
+		assertResourceMapEqual(t, cache.IndexReturnedResourcesByName(out.(*cache.RawDeltaResponse).Resources), snapshot2.GetResourcesAndTTL(rsrc.EndpointType))
 		sub := subscriptions[testTypes[0]]
 		sub.SetReturnedResources(out.GetNextVersionMap())
 		subscriptions[testTypes[0]] = sub
@@ -147,7 +147,7 @@ func TestDeltaRemoveResources(t *testing.T) {
 			select {
 			case out := <-watches[typ]:
 				snapshot := fixture.snapshot()
-				assertResourceMapEqual(t, cache.IndexResourcesByName(out.(*cache.RawDeltaResponse).Resources), snapshot.GetResourcesAndTTL(typ))
+				assertResourceMapEqual(t, cache.IndexReturnedResourcesByName(out.(*cache.RawDeltaResponse).Resources), snapshot.GetResourcesAndTTL(typ))
 				nextVersionMap := out.GetNextVersionMap()
 				subscriptions[typ].SetReturnedResources(nextVersionMap)
 			case <-time.After(time.Second):
@@ -186,7 +186,7 @@ func TestDeltaRemoveResources(t *testing.T) {
 	case out := <-watches[testTypes[0]]:
 		snapshot2 := fixture.snapshot()
 		snapshot2.Resources[types.Endpoint] = cache.NewResources(fixture.version2, []types.Resource{})
-		assertResourceMapEqual(t, cache.IndexResourcesByName(out.(*cache.RawDeltaResponse).Resources), snapshot2.GetResourcesAndTTL(rsrc.EndpointType))
+		assertResourceMapEqual(t, cache.IndexReturnedResourcesByName(out.(*cache.RawDeltaResponse).Resources), snapshot2.GetResourcesAndTTL(rsrc.EndpointType))
 		nextVersionMap := out.GetNextVersionMap()
 
 		// make sure the version maps are different since we no longer are tracking any endpoint resources

--- a/pkg/cache/v3/linear_test.go
+++ b/pkg/cache/v3/linear_test.go
@@ -209,14 +209,14 @@ func checkTotalWatchCount(t *testing.T, c *LinearCache, count int) {
 func checkStableVersionsAreNotComputed(t *testing.T, c *LinearCache, resources ...string) {
 	t.Helper()
 	for _, res := range resources {
-		assert.Empty(t, c.resources[res].stableVersion, "stable version not set on resource %s", res)
+		assert.Empty(t, c.resources[res].resourceVersion, "stable version not set on resource %s", res)
 	}
 }
 
 func checkStableVersionsAreComputed(t *testing.T, c *LinearCache, resources ...string) {
 	t.Helper()
 	for _, res := range resources {
-		assert.NotEmpty(t, c.resources[res].stableVersion, "stable version not set on resource %s", res)
+		assert.NotEmpty(t, c.resources[res].resourceVersion, "stable version not set on resource %s", res)
 	}
 }
 

--- a/pkg/cache/v3/resources.go
+++ b/pkg/cache/v3/resources.go
@@ -1,6 +1,14 @@
 package cache
 
-import "github.com/envoyproxy/go-control-plane/pkg/cache/types"
+import (
+	"fmt"
+
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
+
+	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
+	"github.com/envoyproxy/go-control-plane/pkg/resource/v3"
+)
 
 // Resources is a versioned group of resources.
 type Resources struct {
@@ -11,11 +19,161 @@ type Resources struct {
 	Items map[string]types.ResourceWithTTL
 }
 
+// cachedResource is used to track resources added by the user in the cache.
+// It contains the resource itself and its associated version (currently in two different modes).
+type cachedResource struct {
+	// name is the resource name, to avoid having to rely on type-specific logic to retrieve
+	// the resource name.
+	name string
+
+	// ResourceWithTTL is the resource provided by the user. In the future this would likely also
+	// allow to provide opaque, serialized resources.
+	types.ResourceWithTTL
+
+	// cacheVersion is the version of the cache at the time of last update, used in sotw.
+	cacheVersion string
+
+	// resourceVersion is the version of the resource itself (a hash of its content after deterministic marshaling).
+	// It is lazy initialized and should be accessed through getStableVersion.
+	resourceVersion string
+
+	// marshaledContent is the serialized version of the resource, built through deterministic marshaling.
+	// It is lazy initialized on getStableVersion calls.
+	marshaledContent []byte
+}
+
+func newCachedResource(name string, res types.Resource, cacheVersion string) *cachedResource {
+	return &cachedResource{
+		name:            name,
+		ResourceWithTTL: types.ResourceWithTTL{Resource: res},
+		cacheVersion:    cacheVersion,
+	}
+}
+
+func newCachedResources(res map[string]types.ResourceWithTTL, cacheVersion string) map[string]*cachedResource {
+	resources := make(map[string]*cachedResource, len(res))
+	for name, r := range res {
+		resources[name] = &cachedResource{
+			name:            name,
+			ResourceWithTTL: r,
+			cacheVersion:    cacheVersion,
+		}
+	}
+	return resources
+}
+
+func (c *cachedResource) getStableVersion() (string, error) {
+	if c.resourceVersion != "" {
+		return c.resourceVersion, nil
+	}
+
+	marshaledResource, err := MarshalResource(c.Resource)
+	if err != nil {
+		return "", err
+	}
+	c.marshaledContent = marshaledResource
+	c.resourceVersion = HashResource(marshaledResource)
+	return c.resourceVersion, nil
+}
+
+func (c *cachedResource) getVersion(useStableVersion bool) (string, error) {
+	if !useStableVersion {
+		return c.cacheVersion, nil
+	}
+
+	return c.getStableVersion()
+}
+
+type returnedResource struct {
+	types.ResourceWithTTL
+
+	// name of the resource. This avoids the need of introspection, which cannot necessarily be used with opaque types.
+	name string
+	// content and version can be set on resource creation to avoid reserializing the resource in every single response to all clients.
+	// If not set the computation will occur on access and will not be latched to avoid concurrency issues.
+	serialized *anypb.Any
+	version    string
+}
+
+func newReturnedResource(res types.ResourceWithTTL) returnedResource {
+	return returnedResource{
+		ResourceWithTTL: res,
+		name:            GetResourceName(res.Resource),
+	}
+}
+
+func newReturnedResourceFromCache(res *cachedResource) returnedResource {
+	r := returnedResource{
+		name:            res.name,
+		ResourceWithTTL: res.ResourceWithTTL,
+		version:         res.resourceVersion,
+	}
+	if res.marshaledContent != nil {
+		r.serialized = anyFromContent(res.marshaledContent, res.Resource)
+	}
+	return r
+}
+
+func anyFromContent(content []byte, res proto.Message) *anypb.Any {
+	a := new(anypb.Any)
+	a.Value = content
+	a.TypeUrl = resource.APITypePrefix + string(proto.MessageName(res))
+	return a
+}
+
+func (c returnedResource) buildAnyEntryWithVersion() (*anypb.Any, string, error) {
+	a, err := c.buildAnyEntry()
+	if err != nil {
+		return nil, "", err
+	}
+
+	if c.version != "" {
+		return a, c.version, nil
+	}
+
+	return a, HashResource(a.Value), nil
+}
+
+func (c returnedResource) buildAnyEntry() (*anypb.Any, error) {
+	if c.Resource == nil {
+		return nil, nil
+	}
+
+	if c.serialized != nil {
+		return c.serialized, nil
+	}
+
+	m, err := MarshalResource(c.Resource)
+	if err != nil {
+		return nil, fmt.Errorf("failed to serialize resource: %w", err)
+	}
+
+	return anyFromContent(m, c.Resource), nil
+}
+
+// getReturnedResourceNames returns the resource names for a list of valid xDS response types.
+func getReturnedResourceNames(resources []returnedResource) []string {
+	out := make([]string, len(resources))
+	for i, r := range resources {
+		out[i] = r.name
+	}
+	return out
+}
+
 // IndexResourcesByName creates a map from the resource name to the resource.
 func IndexResourcesByName(items []types.ResourceWithTTL) map[string]types.ResourceWithTTL {
 	indexed := make(map[string]types.ResourceWithTTL, len(items))
 	for _, item := range items {
 		indexed[GetResourceName(item.Resource)] = item
+	}
+	return indexed
+}
+
+// IndexReturnedResourcesByName creates a map from the resource name to the resource.
+func IndexReturnedResourcesByName(items []returnedResource) map[string]types.ResourceWithTTL {
+	indexed := make(map[string]types.ResourceWithTTL, len(items))
+	for _, item := range items {
+		indexed[item.name] = item.ResourceWithTTL
 	}
 	return indexed
 }

--- a/pkg/cache/v3/simple.go
+++ b/pkg/cache/v3/simple.go
@@ -502,7 +502,7 @@ func (cache *snapshotCache) respond(ctx context.Context, watch ResponseWatch, re
 }
 
 func createResponse(ctx context.Context, request *Request, resources map[string]types.ResourceWithTTL, version string, heartbeat bool) Response {
-	filtered := make([]types.ResourceWithTTL, 0, len(resources))
+	filtered := make([]returnedResource, 0, len(resources))
 	returnedResources := make(map[string]string, len(resources))
 
 	// Reply only with the requested resources. Envoy may ask each resource
@@ -512,13 +512,13 @@ func createResponse(ctx context.Context, request *Request, resources map[string]
 		set := nameSet(request.GetResourceNames())
 		for name, resource := range resources {
 			if set[name] {
-				filtered = append(filtered, resource)
+				filtered = append(filtered, newReturnedResource(resource))
 				returnedResources[name] = version
 			}
 		}
 	} else {
 		for name, resource := range resources {
-			filtered = append(filtered, resource)
+			filtered = append(filtered, newReturnedResource(resource))
 			returnedResources[name] = version
 		}
 	}
@@ -590,7 +590,7 @@ func (cache *snapshotCache) CreateDeltaWatch(request *DeltaRequest, sub Subscrip
 // Respond to a delta watch with the provided snapshot value. If the response is nil, there has been no state change.
 func (cache *snapshotCache) respondDelta(ctx context.Context, snapshot ResourceSnapshot, request *DeltaRequest, value chan DeltaResponse, sub Subscription) (*RawDeltaResponse, error) {
 	resp := createDeltaResponse(ctx, request, sub, resourceContainer{
-		resourceMap: snapshot.GetResources(request.GetTypeUrl()),
+		resourceMap: newCachedResources(snapshot.GetResourcesAndTTL(request.GetTypeUrl()), snapshot.GetVersion(request.GetTypeUrl())),
 		versionMap:  snapshot.GetVersionMap(request.GetTypeUrl()),
 	}, snapshot.GetVersion(request.GetTypeUrl()))
 
@@ -600,7 +600,7 @@ func (cache *snapshotCache) respondDelta(ctx context.Context, snapshot ResourceS
 	if len(resp.Resources) > 0 || len(resp.RemovedResources) > 0 || (sub.IsWildcard() && request.ResponseNonce == "") {
 		if cache.log != nil {
 			cache.log.Debugf("node: %s, sending delta response for typeURL %s with resources: %v removed resources: %v with wildcard: %t",
-				request.GetNode().GetId(), request.GetTypeUrl(), GetResourceNames(resp.Resources), resp.RemovedResources, sub.IsWildcard())
+				request.GetNode().GetId(), request.GetTypeUrl(), getReturnedResourceNames(resp.Resources), resp.RemovedResources, sub.IsWildcard())
 		}
 		select {
 		case value <- resp:

--- a/pkg/cache/v3/simple_test.go
+++ b/pkg/cache/v3/simple_test.go
@@ -139,7 +139,7 @@ func TestSnapshotCacheWithTTL(t *testing.T) {
 				if gotVersion, _ := out.GetVersion(); gotVersion != fixture.version {
 					t.Errorf("got version %q, want %q", gotVersion, fixture.version)
 				}
-				if !reflect.DeepEqual(cache.IndexResourcesByName(out.(*cache.RawResponse).Resources), snapshotWithTTL.GetResourcesAndTTL(typ)) {
+				if !reflect.DeepEqual(cache.IndexReturnedResourcesByName(out.(*cache.RawResponse).Resources), snapshotWithTTL.GetResourcesAndTTL(typ)) {
 					t.Errorf("get resources %v, want %v", out.(*cache.RawResponse).Resources, snapshotWithTTL.GetResourcesAndTTL(typ))
 				}
 
@@ -173,11 +173,11 @@ func TestSnapshotCacheWithTTL(t *testing.T) {
 					if gotVersion, _ := out.GetVersion(); gotVersion != fixture.version {
 						t.Errorf("got version %q, want %q", gotVersion, fixture.version)
 					}
-					if !reflect.DeepEqual(cache.IndexResourcesByName(out.(*cache.RawResponse).Resources), snapshotWithTTL.GetResourcesAndTTL(typ)) {
+					if !reflect.DeepEqual(cache.IndexReturnedResourcesByName(out.(*cache.RawResponse).Resources), snapshotWithTTL.GetResourcesAndTTL(typ)) {
 						t.Errorf("get resources %v, want %v", out.(*cache.RawResponse).Resources, snapshotWithTTL.GetResources(typ))
 					}
 
-					if !reflect.DeepEqual(cache.IndexResourcesByName(out.(*cache.RawResponse).Resources), snapshotWithTTL.GetResourcesAndTTL(typ)) {
+					if !reflect.DeepEqual(cache.IndexReturnedResourcesByName(out.(*cache.RawResponse).Resources), snapshotWithTTL.GetResourcesAndTTL(typ)) {
 						t.Errorf("get resources %v, want %v", out.(*cache.RawResponse).Resources, snapshotWithTTL.GetResources(typ))
 					}
 
@@ -254,7 +254,7 @@ func TestSnapshotCache(t *testing.T) {
 				if gotVersion, _ := out.GetVersion(); gotVersion != fixture.version {
 					t.Errorf("got version %q, want %q", gotVersion, fixture.version)
 				}
-				if !reflect.DeepEqual(cache.IndexResourcesByName(out.(*cache.RawResponse).Resources), snapshot.GetResourcesAndTTL(typ)) {
+				if !reflect.DeepEqual(cache.IndexReturnedResourcesByName(out.(*cache.RawResponse).Resources), snapshot.GetResourcesAndTTL(typ)) {
 					t.Errorf("get resources %v, want %v", out.(*cache.RawResponse).Resources, snapshot.GetResourcesAndTTL(typ))
 				}
 			case <-time.After(time.Second):
@@ -318,7 +318,7 @@ func TestSnapshotCacheWatch(t *testing.T) {
 					t.Errorf("got version %q, want %q", gotVersion, fixture.version)
 				}
 				snapshot := fixture.snapshot()
-				if !reflect.DeepEqual(cache.IndexResourcesByName(out.(*cache.RawResponse).Resources), snapshot.GetResourcesAndTTL(typ)) {
+				if !reflect.DeepEqual(cache.IndexReturnedResourcesByName(out.(*cache.RawResponse).Resources), snapshot.GetResourcesAndTTL(typ)) {
 					t.Errorf("get resources %v, want %v", out.(*cache.RawResponse).Resources, snapshot.GetResourcesAndTTL(typ))
 				}
 				returnedResources := make(map[string]string)
@@ -362,7 +362,7 @@ func TestSnapshotCacheWatch(t *testing.T) {
 		if gotVersion, _ := out.GetVersion(); gotVersion != fixture.version2 {
 			t.Errorf("got version %q, want %q", gotVersion, fixture.version2)
 		}
-		if !reflect.DeepEqual(cache.IndexResourcesByName(out.(*cache.RawResponse).Resources), snapshot2.Resources[types.Endpoint].Items) {
+		if !reflect.DeepEqual(cache.IndexReturnedResourcesByName(out.(*cache.RawResponse).Resources), snapshot2.Resources[types.Endpoint].Items) {
 			t.Errorf("got resources %v, want %v", out.(*cache.RawResponse).Resources, snapshot2.Resources[types.Endpoint].Items)
 		}
 	case <-time.After(time.Second):
@@ -495,7 +495,7 @@ func TestSnapshotCreateWatchWithResourcePreviouslyNotRequested(t *testing.T) {
 			t.Errorf("got version %q, want %q", gotVersion, fixture.version)
 		}
 		want := map[string]types.ResourceWithTTL{clusterName: snapshot2.Resources[types.Endpoint].Items[clusterName]}
-		if !reflect.DeepEqual(cache.IndexResourcesByName(out.(*cache.RawResponse).Resources), want) {
+		if !reflect.DeepEqual(cache.IndexReturnedResourcesByName(out.(*cache.RawResponse).Resources), want) {
 			t.Errorf("got resources %v, want %v", out.(*cache.RawResponse).Resources, want)
 		}
 	case <-time.After(time.Second):
@@ -519,7 +519,7 @@ func TestSnapshotCreateWatchWithResourcePreviouslyNotRequested(t *testing.T) {
 		if gotVersion, _ := out.GetVersion(); gotVersion != fixture.version {
 			t.Errorf("got version %q, want %q", gotVersion, fixture.version)
 		}
-		if !reflect.DeepEqual(cache.IndexResourcesByName(out.(*cache.RawResponse).Resources), snapshot2.Resources[types.Endpoint].Items) {
+		if !reflect.DeepEqual(cache.IndexReturnedResourcesByName(out.(*cache.RawResponse).Resources), snapshot2.Resources[types.Endpoint].Items) {
 			t.Errorf("got resources %v, want %v", out.(*cache.RawResponse).Resources, snapshot2.Resources[types.Endpoint].Items)
 		}
 	case <-time.After(time.Second):

--- a/pkg/cache/v3/status.go
+++ b/pkg/cache/v3/status.go
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
-	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
 )
 
 // NodeHash computes string identifiers for Envoy nodes.
@@ -136,14 +135,18 @@ func (w ResponseWatch) isDelta() bool {
 	return false
 }
 
-func (w ResponseWatch) buildResponse(updatedResources []types.ResourceWithTTL, _ []string, returnedVersions map[string]string, version string) WatchResponse {
-	return &RawResponse{
+func (w ResponseWatch) buildResponse(updatedResources []*cachedResource, _ []string, returnedVersions map[string]string, version string) WatchResponse {
+	resp := &RawResponse{
 		Request:           w.Request,
-		Resources:         updatedResources,
+		Resources:         make([]returnedResource, 0, len(updatedResources)),
 		ReturnedResources: returnedVersions,
 		Version:           version,
 		Ctx:               context.Background(),
 	}
+	for _, res := range updatedResources {
+		resp.Resources = append(resp.Resources, newReturnedResourceFromCache(res))
+	}
+	return resp
 }
 
 func (w ResponseWatch) useStableVersion() bool {
@@ -190,15 +193,19 @@ func (w DeltaResponseWatch) getSubscription() Subscription {
 	return w.subscription
 }
 
-func (w DeltaResponseWatch) buildResponse(updatedResources []types.ResourceWithTTL, removedResources []string, returnedVersions map[string]string, version string) WatchResponse {
-	return &RawDeltaResponse{
+func (w DeltaResponseWatch) buildResponse(updatedResources []*cachedResource, removedResources []string, returnedVersions map[string]string, version string) WatchResponse {
+	resp := &RawDeltaResponse{
 		DeltaRequest:      w.Request,
-		Resources:         updatedResources,
+		Resources:         make([]returnedResource, 0, len(updatedResources)),
 		RemovedResources:  removedResources,
 		NextVersionMap:    returnedVersions,
 		SystemVersionInfo: version,
 		Ctx:               context.Background(),
 	}
+	for _, res := range updatedResources {
+		resp.Resources = append(resp.Resources, newReturnedResourceFromCache(res))
+	}
+	return resp
 }
 
 func (w DeltaResponseWatch) sendResponse(resp WatchResponse) {

--- a/pkg/server/v3/delta_test.go
+++ b/pkg/server/v3/delta_test.go
@@ -79,12 +79,14 @@ func (config *mockConfigWatcher) CreateDeltaWatch(req *discovery.DeltaDiscoveryR
 	}
 
 	if len(filtered)+len(toRemove) > 0 {
-		out <- &cache.RawDeltaResponse{
-			DeltaRequest:      req,
-			Resources:         filtered,
-			RemovedResources:  toRemove,
-			SystemVersionInfo: "",
-			NextVersionMap:    nextVersionMap,
+		out <- &cache.DeltaPassthroughResponse{
+			DeltaRequest:   req,
+			NextVersionMap: nextVersionMap,
+			DeltaDiscoveryResponse: &discovery.DeltaDiscoveryResponse{
+				TypeUrl:          req.GetTypeUrl(),
+				Resources:        marshalDiscoveryResources(filtered),
+				RemovedResources: toRemove,
+			},
 		}
 	} else {
 		config.deltaWatches++

--- a/pkg/server/v3/server_test.go
+++ b/pkg/server/v3/server_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"google.golang.org/grpc"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -164,7 +165,7 @@ var (
 	runtime            = resource.MakeRuntime(runtimeName)
 	extensionConfig    = resource.MakeExtensionConfig(resource.Ads, extensionConfigName, routeName)
 	opaque             = &core.Address{}
-	opaqueType         = "unknown-type"
+	opaqueType         = rsrc.APITypePrefix + string(proto.MessageName(opaque))
 	testTypes          = []string{
 		rsrc.EndpointType,
 		rsrc.ClusterType,
@@ -181,74 +182,104 @@ var (
 func makeResponses() map[string][]cache.Response {
 	return map[string][]cache.Response{
 		rsrc.EndpointType: {
-			&cache.RawResponse{
-				Version:   "1",
-				Resources: []types.ResourceWithTTL{{Resource: endpoint}},
-				Request:   &discovery.DiscoveryRequest{TypeUrl: rsrc.EndpointType},
+			&cache.PassthroughResponse{
+				Request: &discovery.DiscoveryRequest{TypeUrl: rsrc.EndpointType},
+				DiscoveryResponse: &discovery.DiscoveryResponse{
+					VersionInfo: "1",
+					TypeUrl:     rsrc.EndpointType,
+					Resources:   marshalAnyResources(endpoint),
+				},
 			},
 		},
 		rsrc.ClusterType: {
-			&cache.RawResponse{
-				Version:   "2",
-				Resources: []types.ResourceWithTTL{{Resource: cluster}},
-				Request:   &discovery.DiscoveryRequest{TypeUrl: rsrc.ClusterType},
+			&cache.PassthroughResponse{
+				Request: &discovery.DiscoveryRequest{TypeUrl: rsrc.ClusterType},
+				DiscoveryResponse: &discovery.DiscoveryResponse{
+					VersionInfo: "2",
+					TypeUrl:     rsrc.ClusterType,
+					Resources:   marshalAnyResources(cluster),
+				},
 			},
 		},
 		rsrc.RouteType: {
-			&cache.RawResponse{
-				Version:   "3",
-				Resources: []types.ResourceWithTTL{{Resource: route}},
-				Request:   &discovery.DiscoveryRequest{TypeUrl: rsrc.RouteType},
+			&cache.PassthroughResponse{
+				Request: &discovery.DiscoveryRequest{TypeUrl: rsrc.RouteType},
+				DiscoveryResponse: &discovery.DiscoveryResponse{
+					VersionInfo: "3",
+					TypeUrl:     rsrc.RouteType,
+					Resources:   marshalAnyResources(route),
+				},
 			},
 		},
 		rsrc.ScopedRouteType: {
-			&cache.RawResponse{
-				Version:   "4",
-				Resources: []types.ResourceWithTTL{{Resource: scopedRoute}},
-				Request:   &discovery.DiscoveryRequest{TypeUrl: rsrc.ScopedRouteType},
+			&cache.PassthroughResponse{
+				Request: &discovery.DiscoveryRequest{TypeUrl: rsrc.ScopedRouteType},
+				DiscoveryResponse: &discovery.DiscoveryResponse{
+					VersionInfo: "4",
+					TypeUrl:     rsrc.ScopedRouteType,
+					Resources:   marshalAnyResources(scopedRoute),
+				},
 			},
 		},
 		rsrc.VirtualHostType: {
-			&cache.RawResponse{
-				Version:   "5",
-				Resources: []types.ResourceWithTTL{{Resource: virtualHost}},
-				Request:   &discovery.DiscoveryRequest{TypeUrl: rsrc.VirtualHostType},
+			&cache.PassthroughResponse{
+				Request: &discovery.DiscoveryRequest{TypeUrl: rsrc.VirtualHostType},
+				DiscoveryResponse: &discovery.DiscoveryResponse{
+					VersionInfo: "5",
+					TypeUrl:     rsrc.VirtualHostType,
+					Resources:   marshalAnyResources(virtualHost),
+				},
 			},
 		},
 		rsrc.ListenerType: {
-			&cache.RawResponse{
-				Version:   "6",
-				Resources: []types.ResourceWithTTL{{Resource: httpListener}, {Resource: httpScopedListener}},
-				Request:   &discovery.DiscoveryRequest{TypeUrl: rsrc.ListenerType},
+			&cache.PassthroughResponse{
+				Request: &discovery.DiscoveryRequest{TypeUrl: rsrc.ListenerType},
+				DiscoveryResponse: &discovery.DiscoveryResponse{
+					VersionInfo: "6",
+					TypeUrl:     rsrc.ListenerType,
+					Resources:   marshalAnyResources(httpListener, httpScopedListener),
+				},
 			},
 		},
 		rsrc.SecretType: {
-			&cache.RawResponse{
-				Version:   "7",
-				Resources: []types.ResourceWithTTL{{Resource: secret}},
-				Request:   &discovery.DiscoveryRequest{TypeUrl: rsrc.SecretType},
+			&cache.PassthroughResponse{
+				Request: &discovery.DiscoveryRequest{TypeUrl: rsrc.SecretType},
+				DiscoveryResponse: &discovery.DiscoveryResponse{
+					VersionInfo: "7",
+					TypeUrl:     rsrc.SecretType,
+					Resources:   marshalAnyResources(secret),
+				},
 			},
 		},
 		rsrc.RuntimeType: {
-			&cache.RawResponse{
-				Version:   "8",
-				Resources: []types.ResourceWithTTL{{Resource: runtime}},
-				Request:   &discovery.DiscoveryRequest{TypeUrl: rsrc.RuntimeType},
+			&cache.PassthroughResponse{
+				Request: &discovery.DiscoveryRequest{TypeUrl: rsrc.RuntimeType},
+				DiscoveryResponse: &discovery.DiscoveryResponse{
+					VersionInfo: "8",
+					TypeUrl:     rsrc.RuntimeType,
+					Resources:   marshalAnyResources(runtime),
+				},
 			},
 		},
 		rsrc.ExtensionConfigType: {
-			&cache.RawResponse{
-				Version:   "9",
-				Resources: []types.ResourceWithTTL{{Resource: extensionConfig}},
-				Request:   &discovery.DiscoveryRequest{TypeUrl: rsrc.ExtensionConfigType},
+			&cache.PassthroughResponse{
+				Request: &discovery.DiscoveryRequest{TypeUrl: rsrc.ExtensionConfigType},
+				DiscoveryResponse: &discovery.DiscoveryResponse{
+					VersionInfo: "9",
+					TypeUrl:     rsrc.ExtensionConfigType,
+					Resources:   marshalAnyResources(extensionConfig),
+				},
 			},
 		},
 		// Pass-through type (xDS does not exist for this type)
 		opaqueType: {
-			&cache.RawResponse{
-				Version:   "10",
-				Resources: []types.ResourceWithTTL{{Resource: opaque}},
-				Request:   &discovery.DiscoveryRequest{TypeUrl: opaqueType},
+			&cache.PassthroughResponse{
+				Request: &discovery.DiscoveryRequest{TypeUrl: opaqueType},
+				DiscoveryResponse: &discovery.DiscoveryResponse{
+					VersionInfo: "10",
+					TypeUrl:     opaqueType,
+					Resources:   marshalAnyResources(opaque),
+				},
 			},
 		},
 	}


### PR DESCRIPTION
Currently, when using delta xds (in both caches) or stable sotw in linear cache, every resource in the cache is marshaled to compute its version prior to passing the resource to a response to be sent to clients. 
This leads to a single resource being serialized ( 1 + n ) times, with n being the number of client streams watching the resource. In large deployment cases, for instance for eds keys, n can be very large and the resource itself be quite large (if a lot of endpoints are returned). This serialization time is not fully in sync with the `UpdateResources` or `SetSnapshot` time, but this ends up being significant CPU usage overall. 
This PR updates the resources returned to latch the marshaled resource if computed to no longer re-serialize on a per client basis. The goal is to change the model of resources to also allow opaque resources from the user in the future (potentially provided as `anypb.Any` as the control-plane does not have any need of knowing the resource if the name is provided, and the xds protocol is already based on returning `Any` opaque resources.