### PR TITLE
[Linear] Ensure a resource is only serialized/hashed at most once to reply it

### DIFF
--- a/pkg/cache/v3/cache.go
+++ b/pkg/cache/v3/cache.go
@@ -176,10 +176,10 @@ type RawResponse struct {
 	// Proxy responds with this version as an acknowledgement.
 	Version string
 
-	// Resources to be included in the response.
+	// resources to be included in the response.
 	resources []cachedResource
 
-	// ReturnedResources tracks the resources returned for the subscription and the version when it was last returned,
+	// returnedResources tracks the resources returned for the subscription and the version when it was last returned,
 	// including previously returned ones when using non-full state resources.
 	// It allows the cache to know what the client knows. The server will transparently forward this
 	// across requests, and the cache is responsible for its interpretation.
@@ -206,14 +206,14 @@ type RawDeltaResponse struct {
 	// SystemVersionInfo holds the currently applied response system version and should be used for debugging purposes only.
 	SystemVersionInfo string
 
-	// Resources to be included in the response.
+	// resources to be included in the response.
 	resources []cachedResource
 
-	// RemovedResources is a list of resource aliases which should be dropped by the consuming client.
+	// removedResources is a list of resource aliases which should be dropped by the consuming client.
 	removedResources []string
 
-	// NextVersionMap consists of updated version mappings after this response is applied.
-	NextVersionMap map[string]string
+	// nextVersionMap consists of updated version mappings after this response is applied.
+	nextVersionMap map[string]string
 
 	// Context provided at the time of response creation. This allows associating additional
 	// information with a generated response.
@@ -291,7 +291,7 @@ func NewTestRawDeltaResponse(req *discovery.DeltaDiscoveryRequest, version strin
 		SystemVersionInfo: version,
 		resources:         cachedRes,
 		removedResources:  removedResources,
-		NextVersionMap:    nextVersionMap,
+		nextVersionMap:    nextVersionMap,
 	}
 }
 
@@ -434,7 +434,7 @@ func (r *RawDeltaResponse) GetNextVersionMap() map[string]string {
 
 // GetReturnedResources returns the version map which consists of updated version mappings after this response is applied.
 func (r *RawDeltaResponse) GetReturnedResources() map[string]string {
-	return r.NextVersionMap
+	return r.nextVersionMap
 }
 
 func (r *RawDeltaResponse) GetContext() context.Context {

--- a/pkg/cache/v3/cache.go
+++ b/pkg/cache/v3/cache.go
@@ -17,7 +17,6 @@ package cache
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"sync/atomic"
 
@@ -25,9 +24,8 @@ import (
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/durationpb"
 
-	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
-
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
 )
 
 // Request is an alias for the discovery request type.
@@ -179,13 +177,13 @@ type RawResponse struct {
 	Version string
 
 	// Resources to be included in the response.
-	Resources []types.ResourceWithTTL
+	resources []cachedResource
 
 	// ReturnedResources tracks the resources returned for the subscription and the version when it was last returned,
 	// including previously returned ones when using non-full state resources.
 	// It allows the cache to know what the client knows. The server will transparently forward this
 	// across requests, and the cache is responsible for its interpretation.
-	ReturnedResources map[string]string
+	returnedResources map[string]string
 
 	// Whether this is a heartbeat response. For xDS versions that support TTL, this
 	// will be converted into a response that doesn't contain the actual resource protobuf.
@@ -197,7 +195,7 @@ type RawResponse struct {
 	Ctx context.Context
 
 	// marshaledResponse holds an atomic reference to the serialized discovery response.
-	marshaledResponse atomic.Value
+	marshaledResponse atomic.Pointer[discovery.DiscoveryResponse]
 }
 
 // RawDeltaResponse is a pre-serialized xDS response that utilizes the delta discovery request/response objects.
@@ -209,10 +207,10 @@ type RawDeltaResponse struct {
 	SystemVersionInfo string
 
 	// Resources to be included in the response.
-	Resources []types.ResourceWithTTL
+	resources []cachedResource
 
 	// RemovedResources is a list of resource aliases which should be dropped by the consuming client.
-	RemovedResources []string
+	removedResources []string
 
 	// NextVersionMap consists of updated version mappings after this response is applied.
 	NextVersionMap map[string]string
@@ -222,7 +220,7 @@ type RawDeltaResponse struct {
 	Ctx context.Context
 
 	// Marshaled Resources to be included in the response.
-	marshaledResponse atomic.Value
+	marshaledResponse atomic.Pointer[discovery.DeltaDiscoveryResponse]
 }
 
 var (
@@ -266,44 +264,79 @@ var (
 	_ DeltaResponse = &DeltaPassthroughResponse{}
 )
 
+func NewTestRawResponse(req *discovery.DiscoveryRequest, version string, resources []types.ResourceWithTTL) *RawResponse {
+	cachedRes := []cachedResource{}
+	for _, res := range resources {
+		newRes := newCachedResource(GetResourceName(res.Resource), res.Resource, version)
+		newRes.ttl = res.TTL
+		cachedRes = append(cachedRes, *newRes)
+	}
+	return &RawResponse{
+		Request:   req,
+		Version:   version,
+		resources: cachedRes,
+	}
+}
+
+func NewTestRawDeltaResponse(req *discovery.DeltaDiscoveryRequest, version string, resources []types.ResourceWithTTL, removedResources []string, nextVersionMap map[string]string) *RawDeltaResponse {
+	cachedRes := []cachedResource{}
+	for _, res := range resources {
+		name := GetResourceName(res.Resource)
+		newRes := newCachedResource(name, res.Resource, nextVersionMap[name])
+		newRes.ttl = res.TTL
+		cachedRes = append(cachedRes, *newRes)
+	}
+	return &RawDeltaResponse{
+		DeltaRequest:      req,
+		SystemVersionInfo: version,
+		resources:         cachedRes,
+		removedResources:  removedResources,
+		NextVersionMap:    nextVersionMap,
+	}
+}
+
 // GetDiscoveryResponse performs the marshaling the first time its called and uses the cached response subsequently.
 // This is necessary because the marshaled response does not change across the calls.
 // This caching behavior is important in high throughput scenarios because grpc marshaling has a cost and it drives the cpu utilization under load.
 func (r *RawResponse) GetDiscoveryResponse() (*discovery.DiscoveryResponse, error) {
 	marshaledResponse := r.marshaledResponse.Load()
 
-	if marshaledResponse == nil {
-		marshaledResources := make([]*anypb.Any, len(r.Resources))
-
-		for i, resource := range r.Resources {
-			maybeTtldResource, resourceType, err := r.maybeCreateTTLResource(resource)
-			if err != nil {
-				return nil, err
-			}
-			marshaledResource, err := MarshalResource(maybeTtldResource)
-			if err != nil {
-				return nil, err
-			}
-			marshaledResources[i] = &anypb.Any{
-				TypeUrl: resourceType,
-				Value:   marshaledResource,
-			}
-		}
-
-		marshaledResponse = &discovery.DiscoveryResponse{
-			VersionInfo: r.Version,
-			Resources:   marshaledResources,
-			TypeUrl:     r.GetRequest().GetTypeUrl(),
-		}
-
-		r.marshaledResponse.Store(marshaledResponse)
+	if marshaledResponse != nil {
+		return marshaledResponse, nil
 	}
 
-	return marshaledResponse.(*discovery.DiscoveryResponse), nil
+	marshaledResources := make([]*anypb.Any, len(r.resources))
+
+	for i, resource := range r.resources {
+		marshaledResource, err := r.marshalTTLResource(resource)
+		if err != nil {
+			return nil, fmt.Errorf("processing %s: %w", GetResourceName(resource.resource), err)
+		}
+		marshaledResources[i] = marshaledResource
+	}
+
+	marshaledResponse = &discovery.DiscoveryResponse{
+		VersionInfo: r.Version,
+		Resources:   marshaledResources,
+		TypeUrl:     r.GetRequest().GetTypeUrl(),
+	}
+
+	r.marshaledResponse.Store(marshaledResponse)
+
+	return marshaledResponse, nil
 }
 
 func (r *RawResponse) GetReturnedResources() map[string]string {
-	return r.ReturnedResources
+	return r.returnedResources
+}
+
+// GetRawResources is used internally within go-control-plane. Its interface and content may change
+func (r *RawResponse) GetRawResources() []types.ResourceWithTTL {
+	resources := make([]types.ResourceWithTTL, 0, len(r.resources))
+	for _, res := range r.resources {
+		resources = append(resources, types.ResourceWithTTL{Resource: res.resource, TTL: res.ttl})
+	}
+	return resources
 }
 
 // GetDeltaDiscoveryResponse performs the marshaling the first time its called and uses the cached response subsequently.
@@ -312,39 +345,49 @@ func (r *RawResponse) GetReturnedResources() map[string]string {
 func (r *RawDeltaResponse) GetDeltaDiscoveryResponse() (*discovery.DeltaDiscoveryResponse, error) {
 	marshaledResponse := r.marshaledResponse.Load()
 
-	if marshaledResponse == nil {
-		marshaledResources := make([]*discovery.Resource, len(r.Resources))
-
-		for i, resource := range r.Resources {
-			name := GetResourceName(resource.Resource)
-			marshaledResource, err := MarshalResource(resource.Resource)
-			if err != nil {
-				return nil, err
-			}
-			version := HashResource(marshaledResource)
-			if version == "" {
-				return nil, errors.New("failed to create a resource hash")
-			}
-			marshaledResources[i] = &discovery.Resource{
-				Name: name,
-				Resource: &anypb.Any{
-					TypeUrl: r.GetDeltaRequest().GetTypeUrl(),
-					Value:   marshaledResource,
-				},
-				Version: version,
-			}
-		}
-
-		marshaledResponse = &discovery.DeltaDiscoveryResponse{
-			Resources:         marshaledResources,
-			RemovedResources:  r.RemovedResources,
-			TypeUrl:           r.GetDeltaRequest().GetTypeUrl(),
-			SystemVersionInfo: r.SystemVersionInfo,
-		}
-		r.marshaledResponse.Store(marshaledResponse)
+	if marshaledResponse != nil {
+		return marshaledResponse, nil
 	}
 
-	return marshaledResponse.(*discovery.DeltaDiscoveryResponse), nil
+	marshaledResources := make([]*discovery.Resource, len(r.resources))
+
+	for i, resource := range r.resources {
+		marshaledResource, err := resource.getMarshaledResource()
+		if err != nil {
+			return nil, fmt.Errorf("processing %s: %w", resource.name, err)
+		}
+		version, err := resource.getStableVersion()
+		if err != nil {
+			return nil, fmt.Errorf("processing version of %s: %w", resource.name, err)
+		}
+		marshaledResources[i] = &discovery.Resource{
+			Name: resource.name,
+			Resource: &anypb.Any{
+				TypeUrl: r.GetDeltaRequest().GetTypeUrl(),
+				Value:   marshaledResource,
+			},
+			Version: version,
+		}
+	}
+
+	marshaledResponse = &discovery.DeltaDiscoveryResponse{
+		Resources:         marshaledResources,
+		RemovedResources:  r.removedResources,
+		TypeUrl:           r.GetDeltaRequest().GetTypeUrl(),
+		SystemVersionInfo: r.SystemVersionInfo,
+	}
+	r.marshaledResponse.Store(marshaledResponse)
+
+	return marshaledResponse, nil
+}
+
+// GetRawResources is used internally within go-control-plane. Its interface and content may change
+func (r *RawDeltaResponse) GetRawResources() []types.ResourceWithTTL {
+	resources := make([]types.ResourceWithTTL, 0, len(r.resources))
+	for _, res := range r.resources {
+		resources = append(resources, types.ResourceWithTTL{Resource: res.resource, TTL: res.ttl})
+	}
+	return resources
 }
 
 // GetRequest returns the original Discovery Request.
@@ -400,26 +443,44 @@ func (r *RawDeltaResponse) GetContext() context.Context {
 
 var deltaResourceTypeURL = "type.googleapis.com/" + string(proto.MessageName(&discovery.Resource{}))
 
-func (r *RawResponse) maybeCreateTTLResource(resource types.ResourceWithTTL) (types.Resource, string, error) {
-	if resource.TTL != nil {
-		wrappedResource := &discovery.Resource{
-			Name: GetResourceName(resource.Resource),
-			Ttl:  durationpb.New(*resource.TTL),
+func (r *RawResponse) marshalTTLResource(resource cachedResource) (*anypb.Any, error) {
+	if resource.ttl == nil {
+		marshaled, err := resource.getMarshaledResource()
+		if err != nil {
+			return nil, fmt.Errorf("marshaling: %w", err)
 		}
-
-		if !r.Heartbeat {
-			rsrc, err := anypb.New(resource.Resource)
-			if err != nil {
-				return nil, "", err
-			}
-			rsrc.TypeUrl = r.GetRequest().GetTypeUrl()
-			wrappedResource.Resource = rsrc
-		}
-
-		return wrappedResource, deltaResourceTypeURL, nil
+		return &anypb.Any{
+			TypeUrl: r.GetRequest().GetTypeUrl(),
+			Value:   marshaled,
+		}, nil
 	}
 
-	return resource.Resource, r.GetRequest().GetTypeUrl(), nil
+	wrappedResource := &discovery.Resource{
+		Name: GetResourceName(resource.resource),
+		Ttl:  durationpb.New(*resource.ttl),
+	}
+
+	if !r.Heartbeat {
+		marshaled, err := resource.getMarshaledResource()
+		if err != nil {
+			return nil, fmt.Errorf("marshaling: %w", err)
+		}
+		rsrc := new(anypb.Any)
+		rsrc.TypeUrl = r.GetRequest().GetTypeUrl()
+		rsrc.Value = marshaled
+
+		wrappedResource.Resource = rsrc
+	}
+
+	marshaled, err := MarshalResource(wrappedResource)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling discovery resource: %w", err)
+	}
+
+	return &anypb.Any{
+		TypeUrl: deltaResourceTypeURL,
+		Value:   marshaled,
+	}, nil
 }
 
 // GetDiscoveryResponse returns the final passthrough Discovery Response.

--- a/pkg/cache/v3/cache.go
+++ b/pkg/cache/v3/cache.go
@@ -356,7 +356,7 @@ func (r *RawDeltaResponse) GetDeltaDiscoveryResponse() (*discovery.DeltaDiscover
 		if err != nil {
 			return nil, fmt.Errorf("processing %s: %w", resource.name, err)
 		}
-		version, err := resource.getStableVersion()
+		version, err := resource.getResourceVersion()
 		if err != nil {
 			return nil, fmt.Errorf("processing version of %s: %w", resource.name, err)
 		}

--- a/pkg/cache/v3/cache.go
+++ b/pkg/cache/v3/cache.go
@@ -177,7 +177,7 @@ type RawResponse struct {
 	Version string
 
 	// resources to be included in the response.
-	resources []cachedResource
+	resources []*cachedResource
 
 	// returnedResources tracks the resources returned for the subscription and the version when it was last returned,
 	// including previously returned ones when using non-full state resources.
@@ -207,7 +207,7 @@ type RawDeltaResponse struct {
 	SystemVersionInfo string
 
 	// resources to be included in the response.
-	resources []cachedResource
+	resources []*cachedResource
 
 	// removedResources is a list of resource aliases which should be dropped by the consuming client.
 	removedResources []string
@@ -265,11 +265,11 @@ var (
 )
 
 func NewTestRawResponse(req *discovery.DiscoveryRequest, version string, resources []types.ResourceWithTTL) *RawResponse {
-	cachedRes := []cachedResource{}
+	cachedRes := []*cachedResource{}
 	for _, res := range resources {
 		newRes := newCachedResource(GetResourceName(res.Resource), res.Resource, version)
 		newRes.ttl = res.TTL
-		cachedRes = append(cachedRes, *newRes)
+		cachedRes = append(cachedRes, newRes)
 	}
 	return &RawResponse{
 		Request:   req,
@@ -279,12 +279,12 @@ func NewTestRawResponse(req *discovery.DiscoveryRequest, version string, resourc
 }
 
 func NewTestRawDeltaResponse(req *discovery.DeltaDiscoveryRequest, version string, resources []types.ResourceWithTTL, removedResources []string, nextVersionMap map[string]string) *RawDeltaResponse {
-	cachedRes := []cachedResource{}
+	cachedRes := []*cachedResource{}
 	for _, res := range resources {
 		name := GetResourceName(res.Resource)
 		newRes := newCachedResource(name, res.Resource, nextVersionMap[name])
 		newRes.ttl = res.TTL
-		cachedRes = append(cachedRes, *newRes)
+		cachedRes = append(cachedRes, newRes)
 	}
 	return &RawDeltaResponse{
 		DeltaRequest:      req,
@@ -443,7 +443,7 @@ func (r *RawDeltaResponse) GetContext() context.Context {
 
 var deltaResourceTypeURL = "type.googleapis.com/" + string(proto.MessageName(&discovery.Resource{}))
 
-func (r *RawResponse) marshalTTLResource(resource cachedResource) (*anypb.Any, error) {
+func (r *RawResponse) marshalTTLResource(resource *cachedResource) (*anypb.Any, error) {
 	if resource.ttl == nil {
 		marshaled, err := resource.getMarshaledResource()
 		if err != nil {

--- a/pkg/cache/v3/cache_test.go
+++ b/pkg/cache/v3/cache_test.go
@@ -1,4 +1,4 @@
-package cache_test
+package cache
 
 import (
 	"testing"
@@ -12,7 +12,6 @@ import (
 	route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
-	"github.com/envoyproxy/go-control-plane/pkg/cache/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/resource/v3"
 )
 
@@ -21,11 +20,11 @@ const (
 )
 
 func TestResponseGetDiscoveryResponse(t *testing.T) {
-	routes := []types.ResourceWithTTL{{Resource: &route.RouteConfiguration{Name: resourceName}}}
-	resp := cache.RawResponse{
+	routes := []cachedResource{*newCachedResource(resourceName, &route.RouteConfiguration{Name: resourceName}, "v")}
+	resp := RawResponse{
 		Request:   &discovery.DiscoveryRequest{TypeUrl: resource.RouteType},
 		Version:   "v",
-		Resources: routes,
+		resources: routes,
 	}
 
 	discoveryResponse, err := resp.GetDiscoveryResponse()
@@ -52,7 +51,7 @@ func TestPassthroughResponseGetDiscoveryResponse(t *testing.T) {
 		Resources:   []*anypb.Any{rsrc},
 		VersionInfo: "v",
 	}
-	resp := cache.PassthroughResponse{
+	resp := PassthroughResponse{
 		Request:           &discovery.DiscoveryRequest{TypeUrl: resource.RouteType},
 		DiscoveryResponse: dr,
 	}
@@ -70,11 +69,11 @@ func TestPassthroughResponseGetDiscoveryResponse(t *testing.T) {
 }
 
 func TestHeartbeatResponseGetDiscoveryResponse(t *testing.T) {
-	routes := []types.ResourceWithTTL{{Resource: &route.RouteConfiguration{Name: resourceName}}}
-	resp := cache.RawResponse{
+	routes := []cachedResource{*newCachedResource(resourceName, &route.RouteConfiguration{Name: resourceName}, "v")}
+	resp := RawResponse{
 		Request:   &discovery.DiscoveryRequest{TypeUrl: resource.RouteType},
 		Version:   "v",
-		Resources: routes,
+		resources: routes,
 		Heartbeat: true,
 	}
 

--- a/pkg/cache/v3/cache_test.go
+++ b/pkg/cache/v3/cache_test.go
@@ -20,7 +20,7 @@ const (
 )
 
 func TestResponseGetDiscoveryResponse(t *testing.T) {
-	routes := []cachedResource{*newCachedResource(resourceName, &route.RouteConfiguration{Name: resourceName}, "v")}
+	routes := []*cachedResource{newCachedResource(resourceName, &route.RouteConfiguration{Name: resourceName}, "v")}
 	resp := RawResponse{
 		Request:   &discovery.DiscoveryRequest{TypeUrl: resource.RouteType},
 		Version:   "v",
@@ -69,7 +69,7 @@ func TestPassthroughResponseGetDiscoveryResponse(t *testing.T) {
 }
 
 func TestHeartbeatResponseGetDiscoveryResponse(t *testing.T) {
-	routes := []cachedResource{*newCachedResource(resourceName, &route.RouteConfiguration{Name: resourceName}, "v")}
+	routes := []*cachedResource{newCachedResource(resourceName, &route.RouteConfiguration{Name: resourceName}, "v")}
 	resp := RawResponse{
 		Request:   &discovery.DiscoveryRequest{TypeUrl: resource.RouteType},
 		Version:   "v",

--- a/pkg/cache/v3/delta.go
+++ b/pkg/cache/v3/delta.go
@@ -29,14 +29,14 @@ type resourceContainer struct {
 func createDeltaResponse(ctx context.Context, req *DeltaRequest, sub Subscription, resources resourceContainer, cacheVersion string) *RawDeltaResponse {
 	// variables to build our response with
 	var nextVersionMap map[string]string
-	var filtered []cachedResource
+	var filtered []*cachedResource
 	var toRemove []string
 
 	// If we are handling a wildcard request, we want to respond with all resources
 	switch {
 	case sub.IsWildcard():
 		if len(sub.ReturnedResources()) == 0 {
-			filtered = make([]cachedResource, 0, len(resources.resourceMap))
+			filtered = make([]*cachedResource, 0, len(resources.resourceMap))
 		}
 		nextVersionMap = make(map[string]string, len(resources.resourceMap))
 		for name, r := range resources.resourceMap {
@@ -46,7 +46,7 @@ func createDeltaResponse(ctx context.Context, req *DeltaRequest, sub Subscriptio
 			nextVersionMap[name] = version
 			prevVersion, found := sub.ReturnedResources()[name]
 			if !found || (prevVersion != version) {
-				filtered = append(filtered, *newCachedResource(name, r, version))
+				filtered = append(filtered, newCachedResource(name, r, version))
 			}
 		}
 
@@ -66,7 +66,7 @@ func createDeltaResponse(ctx context.Context, req *DeltaRequest, sub Subscriptio
 			if r, ok := resources.resourceMap[name]; ok {
 				nextVersion := resources.versionMap[name]
 				if prevVersion != nextVersion {
-					filtered = append(filtered, *newCachedResource(name, r, nextVersion))
+					filtered = append(filtered, newCachedResource(name, r, nextVersion))
 				}
 				nextVersionMap[name] = nextVersion
 			} else if found {

--- a/pkg/cache/v3/delta.go
+++ b/pkg/cache/v3/delta.go
@@ -29,14 +29,14 @@ type resourceContainer struct {
 func createDeltaResponse(ctx context.Context, req *DeltaRequest, sub Subscription, resources resourceContainer, cacheVersion string) *RawDeltaResponse {
 	// variables to build our response with
 	var nextVersionMap map[string]string
-	var filtered []types.ResourceWithTTL
+	var filtered []cachedResource
 	var toRemove []string
 
 	// If we are handling a wildcard request, we want to respond with all resources
 	switch {
 	case sub.IsWildcard():
 		if len(sub.ReturnedResources()) == 0 {
-			filtered = make([]types.ResourceWithTTL, 0, len(resources.resourceMap))
+			filtered = make([]cachedResource, 0, len(resources.resourceMap))
 		}
 		nextVersionMap = make(map[string]string, len(resources.resourceMap))
 		for name, r := range resources.resourceMap {
@@ -46,7 +46,7 @@ func createDeltaResponse(ctx context.Context, req *DeltaRequest, sub Subscriptio
 			nextVersionMap[name] = version
 			prevVersion, found := sub.ReturnedResources()[name]
 			if !found || (prevVersion != version) {
-				filtered = append(filtered, types.ResourceWithTTL{Resource: r})
+				filtered = append(filtered, *newCachedResource(name, r, version))
 			}
 		}
 
@@ -66,7 +66,7 @@ func createDeltaResponse(ctx context.Context, req *DeltaRequest, sub Subscriptio
 			if r, ok := resources.resourceMap[name]; ok {
 				nextVersion := resources.versionMap[name]
 				if prevVersion != nextVersion {
-					filtered = append(filtered, types.ResourceWithTTL{Resource: r})
+					filtered = append(filtered, *newCachedResource(name, r, nextVersion))
 				}
 				nextVersionMap[name] = nextVersion
 			} else if found {
@@ -77,8 +77,8 @@ func createDeltaResponse(ctx context.Context, req *DeltaRequest, sub Subscriptio
 
 	return &RawDeltaResponse{
 		DeltaRequest:      req,
-		Resources:         filtered,
-		RemovedResources:  toRemove,
+		resources:         filtered,
+		removedResources:  toRemove,
 		NextVersionMap:    nextVersionMap,
 		SystemVersionInfo: cacheVersion,
 		Ctx:               ctx,

--- a/pkg/cache/v3/delta.go
+++ b/pkg/cache/v3/delta.go
@@ -79,7 +79,7 @@ func createDeltaResponse(ctx context.Context, req *DeltaRequest, sub Subscriptio
 		DeltaRequest:      req,
 		resources:         filtered,
 		removedResources:  toRemove,
-		NextVersionMap:    nextVersionMap,
+		nextVersionMap:    nextVersionMap,
 		SystemVersionInfo: cacheVersion,
 		Ctx:               ctx,
 	}

--- a/pkg/cache/v3/delta_test.go
+++ b/pkg/cache/v3/delta_test.go
@@ -57,7 +57,7 @@ func TestSnapshotCacheDeltaWatch(t *testing.T) {
 			select {
 			case out := <-watches[typ]:
 				snapshot := fixture.snapshot()
-				assertResourceMapEqual(t, cache.IndexResourcesByName(out.(*cache.RawDeltaResponse).Resources), snapshot.GetResourcesAndTTL(typ))
+				assertResourceMapEqual(t, cache.IndexResourcesByName(out.(*cache.RawDeltaResponse).GetRawResources()), snapshot.GetResourcesAndTTL(typ))
 				sub := subscriptions[typ]
 				sub.SetReturnedResources(out.GetNextVersionMap())
 				subscriptions[typ] = sub
@@ -109,7 +109,7 @@ func TestSnapshotCacheDeltaWatch(t *testing.T) {
 	case out := <-watches[testTypes[0]]:
 		snapshot2 := fixture.snapshot()
 		snapshot2.Resources[types.Endpoint] = cache.NewResources(fixture.version2, []types.Resource{resource.MakeEndpoint(clusterName, 9090)})
-		assertResourceMapEqual(t, cache.IndexResourcesByName(out.(*cache.RawDeltaResponse).Resources), snapshot2.GetResourcesAndTTL(rsrc.EndpointType))
+		assertResourceMapEqual(t, cache.IndexResourcesByName(out.(*cache.RawDeltaResponse).GetRawResources()), snapshot2.GetResourcesAndTTL(rsrc.EndpointType))
 		sub := subscriptions[testTypes[0]]
 		sub.SetReturnedResources(out.GetNextVersionMap())
 		subscriptions[testTypes[0]] = sub
@@ -147,7 +147,7 @@ func TestDeltaRemoveResources(t *testing.T) {
 			select {
 			case out := <-watches[typ]:
 				snapshot := fixture.snapshot()
-				assertResourceMapEqual(t, cache.IndexResourcesByName(out.(*cache.RawDeltaResponse).Resources), snapshot.GetResourcesAndTTL(typ))
+				assertResourceMapEqual(t, cache.IndexResourcesByName(out.(*cache.RawDeltaResponse).GetRawResources()), snapshot.GetResourcesAndTTL(typ))
 				nextVersionMap := out.GetNextVersionMap()
 				subscriptions[typ].SetReturnedResources(nextVersionMap)
 			case <-time.After(time.Second):
@@ -186,7 +186,7 @@ func TestDeltaRemoveResources(t *testing.T) {
 	case out := <-watches[testTypes[0]]:
 		snapshot2 := fixture.snapshot()
 		snapshot2.Resources[types.Endpoint] = cache.NewResources(fixture.version2, []types.Resource{})
-		assertResourceMapEqual(t, cache.IndexResourcesByName(out.(*cache.RawDeltaResponse).Resources), snapshot2.GetResourcesAndTTL(rsrc.EndpointType))
+		assertResourceMapEqual(t, cache.IndexResourcesByName(out.(*cache.RawDeltaResponse).GetRawResources()), snapshot2.GetResourcesAndTTL(rsrc.EndpointType))
 		nextVersionMap := out.GetNextVersionMap()
 
 		// make sure the version maps are different since we no longer are tracking any endpoint resources

--- a/pkg/cache/v3/linear.go
+++ b/pkg/cache/v3/linear.go
@@ -64,7 +64,7 @@ func newCachedResourceWithTTL(name string, res types.ResourceWithTTL, cacheVersi
 	}
 }
 
-// getMarshaledResource lazily marshals the resource and return the bytes.
+// getMarshaledResource lazily marshals the resource and returns the bytes.
 // It is not safe to call it concurrently.
 func (c *cachedResource) getMarshaledResource() ([]byte, error) {
 	if c.marshaledResource != nil {
@@ -79,7 +79,7 @@ func (c *cachedResource) getMarshaledResource() ([]byte, error) {
 	return c.marshaledResource, nil
 }
 
-// getStableVersion lazily hashes the resource and return the stable hash used to track version changes.
+// getStableVersion lazily hashes the resource and returns the stable hash used to track version changes.
 // It is not safe to call it concurrently.
 func (c *cachedResource) getStableVersion() (string, error) {
 	if c.stableVersion != "" {

--- a/pkg/cache/v3/linear.go
+++ b/pkg/cache/v3/linear.go
@@ -38,84 +38,52 @@ type cachedResource struct {
 	// cacheVersion is the version of the cache at the time of last update, used in sotw.
 	cacheVersion string
 
-	// stableVersion is the version of the resource itself (a hash of its content after deterministic marshaling).
-	// It is lazy initialized and should be accessed through getStableVersion.
-	stableVersion string
-
-	// marshaledResource contains the marshaled version of the resource.
-	// It is lazy initialized and should be accessed through getMarshaledResource
-	marshaledResource []byte
-
-	// mu is the mutex used to lazy compute the marshaled resource and stable version.
-	mu sync.Mutex
+	marshalFunc                func() ([]byte, error)
+	computeResourceVersionFunc func() (string, error)
 }
 
 func newCachedResource(name string, res types.Resource, cacheVersion string) *cachedResource {
+	marshalFunc := sync.OnceValues(func() ([]byte, error) {
+		return MarshalResource(res)
+	})
 	return &cachedResource{
 		name:         name,
 		resource:     res,
 		cacheVersion: cacheVersion,
+		marshalFunc:  marshalFunc,
+		computeResourceVersionFunc: sync.OnceValues(func() (string, error) {
+			marshaled, err := marshalFunc()
+			if err != nil {
+				return "", fmt.Errorf("marshaling resource: %w", err)
+			}
+			return HashResource(marshaled), nil
+		}),
 	}
 }
 
 func newCachedResourceWithTTL(name string, res types.ResourceWithTTL, cacheVersion string) *cachedResource {
-	return &cachedResource{
-		name:         name,
-		resource:     res.Resource,
-		ttl:          res.TTL,
-		cacheVersion: cacheVersion,
-	}
+	cachedRes := newCachedResource(name, res.Resource, cacheVersion)
+	cachedRes.ttl = res.TTL
+	return cachedRes
 }
 
 // getMarshaledResource lazily marshals the resource and returns the bytes.
 func (c *cachedResource) getMarshaledResource() ([]byte, error) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	return c.marshalResourceLocked()
+	return c.marshalFunc()
 }
 
-func (c *cachedResource) marshalResourceLocked() ([]byte, error) {
-	if c.marshaledResource != nil {
-		return c.marshaledResource, nil
-	}
-
-	marshaledResource, err := MarshalResource(c.resource)
-	if err != nil {
-		return nil, err
-	}
-	c.marshaledResource = marshaledResource
-	return c.marshaledResource, nil
-}
-
-// getStableVersion lazily hashes the resource and returns the stable hash used to track version changes.
-func (c *cachedResource) getStableVersion() (string, error) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	return c.computeStableVersionLocked()
-}
-
-func (c *cachedResource) computeStableVersionLocked() (string, error) {
-	if c.stableVersion != "" {
-		return c.stableVersion, nil
-	}
-
-	marshaledResource, err := c.marshalResourceLocked()
-	if err != nil {
-		return "", err
-	}
-	c.stableVersion = HashResource(marshaledResource)
-	return c.stableVersion, nil
+// getResourceVersion lazily hashes the resource and returns the stable hash used to track version changes.
+func (c *cachedResource) getResourceVersion() (string, error) {
+	return c.computeResourceVersionFunc()
 }
 
 // getVersion returns the requested version.
-func (c *cachedResource) getVersion(useStableVersion bool) (string, error) {
-	if !useStableVersion {
+func (c *cachedResource) getVersion(useResourceVersion bool) (string, error) {
+	if !useResourceVersion {
 		return c.cacheVersion, nil
 	}
 
-	return c.getStableVersion()
+	return c.getResourceVersion()
 }
 
 type watch interface {
@@ -123,8 +91,8 @@ type watch interface {
 	// It should not be used to take functional decisions, but is still currently used pending final changes.
 	// It can be used to generate statistics.
 	isDelta() bool
-	// useStableVersion indicates whether versions returned in the response are built using stable versions instead of cache update versions.
-	useStableVersion() bool
+	// useResourceVersion indicates whether versions returned in the response are built using resource versions instead of cache update versions.
+	useResourceVersion() bool
 	// sendFullStateResponses requires that all resources matching the request, with no regards to which ones actually updated, must be provided in the response.
 	// As a consequence, sending a response with no resources has a functional meaning of no matching resources available.
 	sendFullStateResponses() bool
@@ -173,11 +141,11 @@ type LinearCache struct {
 	// cache instances and avoid issues of version reuse.
 	versionPrefix string
 
-	// useStableVersionsInSotw switches to a new version model for sotw watches.
-	// When activated, versions are stored in subscriptions using stable versions, and the response version
-	// is an hash of the returned versions to allow watch resumptions when reconnecting to the cache with a
+	// useResourceVersionsInSotw switches to a new version model for sotw watches.
+	// When activated, versions are stored in subscriptions using resource versions, and the response version
+	// is a hash of the returned versions to allow watch resumptions when reconnecting to the cache with a
 	// new subscription.
-	useStableVersionsInSotw bool
+	useResourceVersionsInSotw bool
 
 	watchCount int
 
@@ -194,7 +162,7 @@ type LinearCacheOption func(*LinearCache)
 // WithVersionPrefix sets a version prefix of the form "prefixN" in the version info.
 // Version prefix can be used to distinguish replicated instances of the cache, in case
 // a client re-connects to another instance.
-// Deprecated: use WithSotwStableVersions instead to avoid issues when reconnecting to other instances
+// Deprecated: use WithSotwResourceVersions instead to avoid issues when reconnecting to other instances
 // while avoiding resending resources if unchanged.
 func WithVersionPrefix(prefix string) LinearCacheOption {
 	return func(cache *LinearCache) {
@@ -217,15 +185,15 @@ func WithLogger(log log.Logger) LinearCacheOption {
 	}
 }
 
-// WithSotwStableVersions changes the versions returned in sotw to encode the list of resources known
+// WithSotwResourceVersions changes the versions returned in sotw to encode the list of resources known
 // in the subscription.
-// The use of stable versions for sotw also deduplicates updates to clients if the cache updates are
+// The use of resource versions for sotw also deduplicates updates to clients if the cache updates are
 // not changing the content of the resource.
 // When used, the use of WithVersionPrefix is no longer needed to manage reconnection to other instances
 // and should not be used.
-func WithSotwStableVersions() LinearCacheOption {
+func WithSotwResourceVersions() LinearCacheOption {
 	return func(cache *LinearCache) {
-		cache.useStableVersionsInSotw = true
+		cache.useResourceVersionsInSotw = true
 	}
 }
 
@@ -253,10 +221,10 @@ func NewLinearCache(typeURL string, opts ...LinearCacheOption) *LinearCache {
 // computeResourceChange compares the subscription known resources and the cache current state to compute the list of resources
 // which have changed and should be notified to the user.
 //
-// The useStableVersion argument defines what version type to use for resources:
+// The useResourceVersion argument defines what version type to use for resources:
 //   - if set to false versions are based on when resources were updated in the cache.
 //   - if set to true versions are a stable property of the resource, with no regard to when it was added to the cache.
-func (cache *LinearCache) computeResourceChange(sub Subscription, useStableVersion bool) (updated, removed []string, err error) {
+func (cache *LinearCache) computeResourceChange(sub Subscription, useResourceVersion bool) (updated, removed []string, err error) {
 	var changedResources []string
 	var removedResources []string
 
@@ -268,7 +236,7 @@ func (cache *LinearCache) computeResourceChange(sub Subscription, useStableVersi
 				// This resource is not yet known by the client (new resource added in the cache or newly subscribed).
 				changedResources = append(changedResources, resourceName)
 			} else {
-				resourceVersion, err := resource.getVersion(useStableVersion)
+				resourceVersion, err := resource.getVersion(useResourceVersion)
 				if err != nil {
 					return nil, nil, fmt.Errorf("failed to compute version of %s: %w", resourceName, err)
 				}
@@ -304,7 +272,7 @@ func (cache *LinearCache) computeResourceChange(sub Subscription, useStableVersi
 				// This resource is not yet known by the client (new resource added in the cache or newly subscribed).
 				changedResources = append(changedResources, resourceName)
 			} else {
-				resourceVersion, err := res.getVersion(useStableVersion)
+				resourceVersion, err := res.getVersion(useResourceVersion)
 				if err != nil {
 					return nil, nil, fmt.Errorf("failed to compute version of %s: %w", resourceName, err)
 				}
@@ -329,7 +297,7 @@ func (cache *LinearCache) computeResourceChange(sub Subscription, useStableVersi
 
 func (cache *LinearCache) computeResponse(watch watch, replyEvenIfEmpty bool) (WatchResponse, error) {
 	sub := watch.getSubscription()
-	changedResources, removedResources, err := cache.computeResourceChange(sub, watch.useStableVersion())
+	changedResources, removedResources, err := cache.computeResourceChange(sub, watch.useResourceVersion())
 	if err != nil {
 		return nil, err
 	}
@@ -388,7 +356,7 @@ func (cache *LinearCache) computeResponse(watch watch, replyEvenIfEmpty bool) (W
 	for _, resourceName := range resourcesToReturn {
 		cachedResource := cache.resources[resourceName]
 		resources = append(resources, cachedResource)
-		version, err := cachedResource.getVersion(watch.useStableVersion())
+		version, err := cachedResource.getVersion(watch.useResourceVersion())
 		if err != nil {
 			return nil, fmt.Errorf("failed to compute version of %s: %w", resourceName, err)
 		}
@@ -403,8 +371,8 @@ func (cache *LinearCache) computeResponse(watch watch, replyEvenIfEmpty bool) (W
 
 	// TODO(valerian-roche): remove this leak of delta/sotw behavior here.
 	responseVersion := cache.getVersion()
-	if watch.useStableVersion() && !watch.isDelta() {
-		responseVersion = cache.versionPrefix + computeSotwStableVersion(returnedVersions)
+	if watch.useResourceVersion() && !watch.isDelta() {
+		responseVersion = cache.versionPrefix + computeSotwResourceVersion(returnedVersions)
 	}
 
 	return watch.buildResponse(resources, removedResources, returnedVersions, responseVersion), nil
@@ -516,8 +484,8 @@ func (cache *LinearCache) SetResources(resources map[string]types.Resource) {
 	}
 
 	// We assume all resources passed to SetResources are changed.
-	// In delta and if stable versions are used for sotw, identical resources will not trigger watches.
-	// In sotw without stable versions used, all those resources will trigger watches, even if identical.
+	// In delta and if resource versions are used for sotw, identical resources will not trigger watches.
+	// In sotw without resource versions used, all those resources will trigger watches, even if identical.
 	for name, resource := range resources {
 		cache.resources[name] = newCachedResource(name, resource, version)
 		modified = append(modified, name)
@@ -568,13 +536,13 @@ func (cache *LinearCache) CreateWatch(request *Request, sub Subscription, value 
 	// We could optimize the reconnection case here if:
 	//  - we take the assumption that clients will not start requesting wildcard while providing a version. We could then ignore requests providing the resources.
 	//  - we use the version as some form of hash of resources known, and we can then consider it as a way to correctly verify whether all resources are unchanged.
-	// When using the `WithSotwStableVersions` option, this optimization is activated and avoids resending all the dataset on wildcard watch resumption if no change has occurred.
+	// When using the `WithSotwResourceVersions` option, this optimization is activated and avoids resending all the dataset on wildcard watch resumption if no change has occurred.
 	watch := ResponseWatch{
-		Request:             request,
-		Response:            value,
-		subscription:        sub,
-		enableStableVersion: cache.useStableVersionsInSotw,
-		fullStateResponses:  ResourceRequiresFullStateInSotw(cache.typeURL),
+		Request:               request,
+		Response:              value,
+		subscription:          sub,
+		enableResourceVersion: cache.useResourceVersionsInSotw,
+		fullStateResponses:    ResourceRequiresFullStateInSotw(cache.typeURL),
 	}
 
 	cache.mu.Lock()
@@ -590,12 +558,12 @@ func (cache *LinearCache) CreateWatch(request *Request, sub Subscription, value 
 		//  - is the first
 		//  - is wildcard
 		//  - provides a non-empty version, matching the version prefix
-		// and the cache uses stable versions, if the generated versions are the same as the previous one, we do not return the response.
+		// and the cache uses resource versions, if the generated versions are the same as the previous one, we do not return the response.
 		// This avoids resending all data if the new subscription is just a resumption of the previous one.
 		// This optimization is only done on wildcard as we cannot track if a subscription is "new" at this stage and needs to be returned.
 		// In the context of wildcard it could be incorrect if the subscription is newly wildcard, and we already returned all objects,
 		// but as of Q1-2024 there are no known usecases of a subscription becoming wildcard (in envoy of xds-grpc).
-		if cache.useStableVersionsInSotw && sub.IsWildcard() && request.GetResponseNonce() == "" && !replyEvenIfEmpty {
+		if cache.useResourceVersionsInSotw && sub.IsWildcard() && request.GetResponseNonce() == "" && !replyEvenIfEmpty {
 			if request.GetVersionInfo() != response.GetResponseVersion() {
 				// The response has a different returned version map as the request
 				shouldReply = true

--- a/pkg/cache/v3/linear_test.go
+++ b/pkg/cache/v3/linear_test.go
@@ -116,8 +116,8 @@ func verifyResponseResources(t *testing.T, ch <-chan Response, expectedType, exp
 	}
 	out := r.(*RawResponse)
 	resourceNames := []string{}
-	for _, res := range out.Resources {
-		resourceNames = append(resourceNames, GetResourceName(res.Resource))
+	for _, res := range out.resources {
+		resourceNames = append(resourceNames, res.name)
 	}
 	assert.ElementsMatch(t, resourceNames, expectedResources)
 	return r

--- a/pkg/cache/v3/linear_test.go
+++ b/pkg/cache/v3/linear_test.go
@@ -206,20 +206,6 @@ func checkTotalWatchCount(t *testing.T, c *LinearCache, count int) {
 	}
 }
 
-func checkStableVersionsAreNotComputed(t *testing.T, c *LinearCache, resources ...string) {
-	t.Helper()
-	for _, res := range resources {
-		assert.Empty(t, c.resources[res].stableVersion, "stable version not set on resource %s", res)
-	}
-}
-
-func checkStableVersionsAreComputed(t *testing.T, c *LinearCache, resources ...string) {
-	t.Helper()
-	for _, res := range resources {
-		assert.NotEmpty(t, c.resources[res].stableVersion, "stable version not set on resource %s", res)
-	}
-}
-
 func mustBlock(t *testing.T, w <-chan Response) {
 	t.Helper()
 	select {
@@ -775,8 +761,6 @@ func TestLinearDeltaResourceUpdate(t *testing.T) {
 	hashB := hashResource(t, b)
 	err = c.UpdateResource("b", b)
 	require.NoError(t, err)
-	// There is currently no delta watch
-	checkStableVersionsAreNotComputed(t, c, "a", "b")
 
 	req := &DeltaRequest{TypeUrl: testType, ResourceNamesSubscribe: []string{"a", "b"}}
 	w := make(chan DeltaResponse, 1)
@@ -784,7 +768,6 @@ func TestLinearDeltaResourceUpdate(t *testing.T) {
 	require.NoError(t, err)
 	checkTotalWatchCount(t, c, 0)
 	verifyDeltaResponse(t, w, []resourceInfo{{"b", hashB}, {"a", hashA}}, nil)
-	checkStableVersionsAreComputed(t, c, "a", "b")
 
 	req = &DeltaRequest{TypeUrl: testType, ResourceNamesSubscribe: []string{"a", "b"}, InitialResourceVersions: map[string]string{"a": hashA, "b": hashB}}
 	w = make(chan DeltaResponse, 1)
@@ -800,7 +783,6 @@ func TestLinearDeltaResourceUpdate(t *testing.T) {
 	err = c.UpdateResource("a", a)
 	require.NoError(t, err)
 	verifyDeltaResponse(t, w, []resourceInfo{{"a", hashA}}, nil)
-	checkStableVersionsAreComputed(t, c, "a")
 }
 
 func TestLinearDeltaResourceDelete(t *testing.T) {
@@ -857,7 +839,6 @@ func TestLinearDeltaMultiResourceUpdates(t *testing.T) {
 	require.NoError(t, err)
 	resp := <-w
 	validateDeltaResponse(t, resp, []resourceInfo{{"a", hashA}, {"b", hashB}}, nil)
-	checkStableVersionsAreComputed(t, c, "a", "b")
 	assert.Equal(t, 2, c.NumResources())
 
 	sub.SetReturnedResources(resp.GetNextVersionMap())
@@ -880,7 +861,6 @@ func TestLinearDeltaMultiResourceUpdates(t *testing.T) {
 	require.NoError(t, err)
 	resp = <-w
 	validateDeltaResponse(t, resp, []resourceInfo{{"a", hashA}, {"b", hashB}}, nil)
-	checkStableVersionsAreComputed(t, c, "a", "b")
 	assert.Equal(t, 2, c.NumResources())
 	sub.SetReturnedResources(resp.GetNextVersionMap())
 
@@ -900,9 +880,7 @@ func TestLinearDeltaMultiResourceUpdates(t *testing.T) {
 	assert.NotContains(t, c.resources, "b", "resource with name b was found in cache")
 	resp = <-w
 	validateDeltaResponse(t, resp, []resourceInfo{{"a", hashA}}, []string{"b"})
-	checkStableVersionsAreComputed(t, c, "a")
 	// d is not watched currently
-	checkStableVersionsAreNotComputed(t, c, "d")
 	assert.Equal(t, 2, c.NumResources())
 	sub.SetReturnedResources(resp.GetNextVersionMap())
 
@@ -919,7 +897,6 @@ func TestLinearDeltaMultiResourceUpdates(t *testing.T) {
 	assert.NotContains(t, c.resources, "d", "resource with name d was found in cache")
 	resp = <-w
 	validateDeltaResponse(t, resp, []resourceInfo{{"b", hashB}}, nil) // d is not watched and should not be returned
-	checkStableVersionsAreComputed(t, c, "b")
 	assert.Equal(t, 2, c.NumResources())
 	sub.SetReturnedResources(resp.GetNextVersionMap())
 
@@ -937,7 +914,6 @@ func TestLinearDeltaMultiResourceUpdates(t *testing.T) {
 	require.NoError(t, err)
 	verifyDeltaResponse(t, w, []resourceInfo{{"b", hashB}, {"d", hashD}}, nil)
 	// d is now watched and should be returned
-	checkStableVersionsAreComputed(t, c, "b", "d")
 	assert.Equal(t, 3, c.NumResources())
 
 	// Wildcard update/delete
@@ -975,8 +951,6 @@ func TestLinearMixedWatches(t *testing.T) {
 	_, err = c.CreateWatch(sotwReq, sotwSub, w)
 	require.NoError(t, err)
 	mustBlock(t, w)
-	// Only sotw watches, should not have triggered stable resource computation
-	checkStableVersionsAreNotComputed(t, c, "a", "b")
 	checkTotalWatchCount(t, c, 1)
 	checkWatchCount(t, c, "a", 1)
 	checkWatchCount(t, c, "b", 1)
@@ -990,7 +964,6 @@ func TestLinearMixedWatches(t *testing.T) {
 	// This behavior is currently invalid for cds and lds, but due to a current limitation of linear cache sotw implementation
 	resp := verifyResponseResources(t, w, resource.EndpointType, c.getVersion(), "a")
 	updateFromSotwResponse(resp, &sotwSub, sotwReq)
-	checkStableVersionsAreNotComputed(t, c, "a", "b")
 	checkTotalWatchCount(t, c, 0)
 	checkWatchCount(t, c, "a", 0)
 	checkWatchCount(t, c, "b", 0)
@@ -998,7 +971,6 @@ func TestLinearMixedWatches(t *testing.T) {
 	_, err = c.CreateWatch(sotwReq, sotwSub, w)
 	require.NoError(t, err)
 	mustBlock(t, w)
-	checkStableVersionsAreNotComputed(t, c, "a", "b")
 	checkTotalWatchCount(t, c, 1)
 
 	deltaReq := &DeltaRequest{TypeUrl: resource.EndpointType, ResourceNamesSubscribe: []string{"a", "b"}, InitialResourceVersions: map[string]string{"a": hashA, "b": hashB}}
@@ -1009,7 +981,6 @@ func TestLinearMixedWatches(t *testing.T) {
 	require.NoError(t, err)
 	mustBlockDelta(t, wd)
 	checkTotalWatchCount(t, c, 2)
-	checkStableVersionsAreComputed(t, c, "a", "b")
 	checkWatchCount(t, c, "a", 2)
 	checkWatchCount(t, c, "b", 2)
 
@@ -1485,7 +1456,7 @@ func TestLinearSotwVersion(t *testing.T) {
 			"b": &endpoint.ClusterLoadAssignment{ClusterName: "b"},
 			"c": &endpoint.ClusterLoadAssignment{ClusterName: "c"},
 		},
-	), WithSotwStableVersions())
+	), WithSotwResourceVersions())
 
 	buildRequest := func(res []string, version string) *discovery.DiscoveryRequest {
 		return &discovery.DiscoveryRequest{
@@ -1542,7 +1513,7 @@ func TestLinearSotwVersion(t *testing.T) {
 				"b": &endpoint.ClusterLoadAssignment{ClusterName: "b"},
 				"c": &endpoint.ClusterLoadAssignment{ClusterName: "c"},
 			},
-		), WithSotwStableVersions(), WithVersionPrefix("test-prefix-"))
+		), WithSotwResourceVersions(), WithVersionPrefix("test-prefix-"))
 
 		t.Run("watch opened with the same last version missing prefix", func(t *testing.T) {
 			req := buildRequest([]string{}, lastVersion)

--- a/pkg/cache/v3/resource.go
+++ b/pkg/cache/v3/resource.go
@@ -125,7 +125,7 @@ func GetResourceNames(resources []types.ResourceWithTTL) []string {
 }
 
 // getCachedResourceNames returns the resource names for a list of valid xDS response types.
-func getCachedResourceNames(resources []cachedResource) []string {
+func getCachedResourceNames(resources []*cachedResource) []string {
 	out := make([]string, len(resources))
 	for i, r := range resources {
 		out[i] = GetResourceName(r.resource)

--- a/pkg/cache/v3/resource.go
+++ b/pkg/cache/v3/resource.go
@@ -124,6 +124,15 @@ func GetResourceNames(resources []types.ResourceWithTTL) []string {
 	return out
 }
 
+// getCachedResourceNames returns the resource names for a list of valid xDS response types.
+func getCachedResourceNames(resources []cachedResource) []string {
+	out := make([]string, len(resources))
+	for i, r := range resources {
+		out[i] = GetResourceName(r.resource)
+	}
+	return out
+}
+
 // MarshalResource converts the Resource to MarshaledResource.
 func MarshalResource(resource types.Resource) (types.MarshaledResource, error) {
 	return proto.MarshalOptions{Deterministic: true}.Marshal(resource)

--- a/pkg/cache/v3/simple.go
+++ b/pkg/cache/v3/simple.go
@@ -502,7 +502,7 @@ func (cache *snapshotCache) respond(ctx context.Context, watch ResponseWatch, re
 }
 
 func createResponse(ctx context.Context, request *Request, resources map[string]types.ResourceWithTTL, version string, heartbeat bool) Response {
-	filtered := make([]cachedResource, 0, len(resources))
+	filtered := make([]*cachedResource, 0, len(resources))
 	returnedResources := make(map[string]string, len(resources))
 
 	// Reply only with the requested resources. Envoy may ask each resource
@@ -512,13 +512,13 @@ func createResponse(ctx context.Context, request *Request, resources map[string]
 		set := nameSet(request.GetResourceNames())
 		for name, resource := range resources {
 			if set[name] {
-				filtered = append(filtered, *newCachedResourceWithTTL(name, resource, version))
+				filtered = append(filtered, newCachedResourceWithTTL(name, resource, version))
 				returnedResources[name] = version
 			}
 		}
 	} else {
 		for name, resource := range resources {
-			filtered = append(filtered, *newCachedResourceWithTTL(name, resource, version))
+			filtered = append(filtered, newCachedResourceWithTTL(name, resource, version))
 			returnedResources[name] = version
 		}
 	}

--- a/pkg/cache/v3/simple.go
+++ b/pkg/cache/v3/simple.go
@@ -502,7 +502,7 @@ func (cache *snapshotCache) respond(ctx context.Context, watch ResponseWatch, re
 }
 
 func createResponse(ctx context.Context, request *Request, resources map[string]types.ResourceWithTTL, version string, heartbeat bool) Response {
-	filtered := make([]types.ResourceWithTTL, 0, len(resources))
+	filtered := make([]cachedResource, 0, len(resources))
 	returnedResources := make(map[string]string, len(resources))
 
 	// Reply only with the requested resources. Envoy may ask each resource
@@ -512,13 +512,13 @@ func createResponse(ctx context.Context, request *Request, resources map[string]
 		set := nameSet(request.GetResourceNames())
 		for name, resource := range resources {
 			if set[name] {
-				filtered = append(filtered, resource)
+				filtered = append(filtered, *newCachedResourceWithTTL(name, resource, version))
 				returnedResources[name] = version
 			}
 		}
 	} else {
 		for name, resource := range resources {
-			filtered = append(filtered, resource)
+			filtered = append(filtered, *newCachedResourceWithTTL(name, resource, version))
 			returnedResources[name] = version
 		}
 	}
@@ -526,8 +526,8 @@ func createResponse(ctx context.Context, request *Request, resources map[string]
 	return &RawResponse{
 		Request:           request,
 		Version:           version,
-		Resources:         filtered,
-		ReturnedResources: returnedResources,
+		resources:         filtered,
+		returnedResources: returnedResources,
 		Heartbeat:         heartbeat,
 		Ctx:               ctx,
 	}
@@ -597,10 +597,10 @@ func (cache *snapshotCache) respondDelta(ctx context.Context, snapshot ResourceS
 	// Only send a response if there were changes
 	// We want to respond immediately for the first wildcard request in a stream, even if the response is empty
 	// otherwise, envoy won't complete initialization
-	if len(resp.Resources) > 0 || len(resp.RemovedResources) > 0 || (sub.IsWildcard() && request.ResponseNonce == "") {
+	if len(resp.resources) > 0 || len(resp.removedResources) > 0 || (sub.IsWildcard() && request.ResponseNonce == "") {
 		if cache.log != nil {
 			cache.log.Debugf("node: %s, sending delta response for typeURL %s with resources: %v removed resources: %v with wildcard: %t",
-				request.GetNode().GetId(), request.GetTypeUrl(), GetResourceNames(resp.Resources), resp.RemovedResources, sub.IsWildcard())
+				request.GetNode().GetId(), request.GetTypeUrl(), getCachedResourceNames(resp.resources), resp.removedResources, sub.IsWildcard())
 		}
 		select {
 		case value <- resp:

--- a/pkg/cache/v3/simple_test.go
+++ b/pkg/cache/v3/simple_test.go
@@ -139,8 +139,8 @@ func TestSnapshotCacheWithTTL(t *testing.T) {
 				if gotVersion, _ := out.GetVersion(); gotVersion != fixture.version {
 					t.Errorf("got version %q, want %q", gotVersion, fixture.version)
 				}
-				if !reflect.DeepEqual(cache.IndexResourcesByName(out.(*cache.RawResponse).Resources), snapshotWithTTL.GetResourcesAndTTL(typ)) {
-					t.Errorf("get resources %v, want %v", out.(*cache.RawResponse).Resources, snapshotWithTTL.GetResourcesAndTTL(typ))
+				if !reflect.DeepEqual(cache.IndexResourcesByName(out.(*cache.RawResponse).GetRawResources()), snapshotWithTTL.GetResourcesAndTTL(typ)) {
+					t.Errorf("get resources %v, want %v", out.(*cache.RawResponse).GetRawResources(), snapshotWithTTL.GetResourcesAndTTL(typ))
 				}
 
 				updateFromSotwResponse(out, &sub, req)
@@ -173,12 +173,12 @@ func TestSnapshotCacheWithTTL(t *testing.T) {
 					if gotVersion, _ := out.GetVersion(); gotVersion != fixture.version {
 						t.Errorf("got version %q, want %q", gotVersion, fixture.version)
 					}
-					if !reflect.DeepEqual(cache.IndexResourcesByName(out.(*cache.RawResponse).Resources), snapshotWithTTL.GetResourcesAndTTL(typ)) {
-						t.Errorf("get resources %v, want %v", out.(*cache.RawResponse).Resources, snapshotWithTTL.GetResources(typ))
+					if !reflect.DeepEqual(cache.IndexResourcesByName(out.(*cache.RawResponse).GetRawResources()), snapshotWithTTL.GetResourcesAndTTL(typ)) {
+						t.Errorf("get resources %v, want %v", out.(*cache.RawResponse).GetRawResources(), snapshotWithTTL.GetResources(typ))
 					}
 
-					if !reflect.DeepEqual(cache.IndexResourcesByName(out.(*cache.RawResponse).Resources), snapshotWithTTL.GetResourcesAndTTL(typ)) {
-						t.Errorf("get resources %v, want %v", out.(*cache.RawResponse).Resources, snapshotWithTTL.GetResources(typ))
+					if !reflect.DeepEqual(cache.IndexResourcesByName(out.(*cache.RawResponse).GetRawResources()), snapshotWithTTL.GetResourcesAndTTL(typ)) {
+						t.Errorf("get resources %v, want %v", out.(*cache.RawResponse).GetRawResources(), snapshotWithTTL.GetResources(typ))
 					}
 
 					updatesByType[typ]++
@@ -254,8 +254,8 @@ func TestSnapshotCache(t *testing.T) {
 				if gotVersion, _ := out.GetVersion(); gotVersion != fixture.version {
 					t.Errorf("got version %q, want %q", gotVersion, fixture.version)
 				}
-				if !reflect.DeepEqual(cache.IndexResourcesByName(out.(*cache.RawResponse).Resources), snapshot.GetResourcesAndTTL(typ)) {
-					t.Errorf("get resources %v, want %v", out.(*cache.RawResponse).Resources, snapshot.GetResourcesAndTTL(typ))
+				if !reflect.DeepEqual(cache.IndexResourcesByName(out.(*cache.RawResponse).GetRawResources()), snapshot.GetResourcesAndTTL(typ)) {
+					t.Errorf("get resources %v, want %v", out.(*cache.RawResponse).GetRawResources(), snapshot.GetResourcesAndTTL(typ))
 				}
 			case <-time.After(time.Second):
 				t.Fatal("failed to receive snapshot response")
@@ -318,8 +318,8 @@ func TestSnapshotCacheWatch(t *testing.T) {
 					t.Errorf("got version %q, want %q", gotVersion, fixture.version)
 				}
 				snapshot := fixture.snapshot()
-				if !reflect.DeepEqual(cache.IndexResourcesByName(out.(*cache.RawResponse).Resources), snapshot.GetResourcesAndTTL(typ)) {
-					t.Errorf("get resources %v, want %v", out.(*cache.RawResponse).Resources, snapshot.GetResourcesAndTTL(typ))
+				if !reflect.DeepEqual(cache.IndexResourcesByName(out.(*cache.RawResponse).GetRawResources()), snapshot.GetResourcesAndTTL(typ)) {
+					t.Errorf("get resources %v, want %v", out.(*cache.RawResponse).GetRawResources(), snapshot.GetResourcesAndTTL(typ))
 				}
 				returnedResources := make(map[string]string)
 				// Update sub to track what was returned
@@ -362,8 +362,8 @@ func TestSnapshotCacheWatch(t *testing.T) {
 		if gotVersion, _ := out.GetVersion(); gotVersion != fixture.version2 {
 			t.Errorf("got version %q, want %q", gotVersion, fixture.version2)
 		}
-		if !reflect.DeepEqual(cache.IndexResourcesByName(out.(*cache.RawResponse).Resources), snapshot2.Resources[types.Endpoint].Items) {
-			t.Errorf("got resources %v, want %v", out.(*cache.RawResponse).Resources, snapshot2.Resources[types.Endpoint].Items)
+		if !reflect.DeepEqual(cache.IndexResourcesByName(out.(*cache.RawResponse).GetRawResources()), snapshot2.Resources[types.Endpoint].Items) {
+			t.Errorf("got resources %v, want %v", out.(*cache.RawResponse).GetRawResources(), snapshot2.Resources[types.Endpoint].Items)
 		}
 	case <-time.After(time.Second):
 		t.Fatal("failed to receive snapshot response")
@@ -495,8 +495,8 @@ func TestSnapshotCreateWatchWithResourcePreviouslyNotRequested(t *testing.T) {
 			t.Errorf("got version %q, want %q", gotVersion, fixture.version)
 		}
 		want := map[string]types.ResourceWithTTL{clusterName: snapshot2.Resources[types.Endpoint].Items[clusterName]}
-		if !reflect.DeepEqual(cache.IndexResourcesByName(out.(*cache.RawResponse).Resources), want) {
-			t.Errorf("got resources %v, want %v", out.(*cache.RawResponse).Resources, want)
+		if !reflect.DeepEqual(cache.IndexResourcesByName(out.(*cache.RawResponse).GetRawResources()), want) {
+			t.Errorf("got resources %v, want %v", out.(*cache.RawResponse).GetRawResources(), want)
 		}
 	case <-time.After(time.Second):
 		t.Fatal("failed to receive snapshot response")
@@ -519,8 +519,8 @@ func TestSnapshotCreateWatchWithResourcePreviouslyNotRequested(t *testing.T) {
 		if gotVersion, _ := out.GetVersion(); gotVersion != fixture.version {
 			t.Errorf("got version %q, want %q", gotVersion, fixture.version)
 		}
-		if !reflect.DeepEqual(cache.IndexResourcesByName(out.(*cache.RawResponse).Resources), snapshot2.Resources[types.Endpoint].Items) {
-			t.Errorf("got resources %v, want %v", out.(*cache.RawResponse).Resources, snapshot2.Resources[types.Endpoint].Items)
+		if !reflect.DeepEqual(cache.IndexResourcesByName(out.(*cache.RawResponse).GetRawResources()), snapshot2.Resources[types.Endpoint].Items) {
+			t.Errorf("got resources %v, want %v", out.(*cache.RawResponse).GetRawResources(), snapshot2.Resources[types.Endpoint].Items)
 		}
 	case <-time.After(time.Second):
 		t.Fatal("failed to receive snapshot response")

--- a/pkg/cache/v3/status.go
+++ b/pkg/cache/v3/status.go
@@ -86,7 +86,7 @@ type statusInfo struct {
 	mu sync.RWMutex
 }
 
-func computeSotwStableVersion(versionMap map[string]string) string {
+func computeSotwResourceVersion(versionMap map[string]string) string {
 	// To enforce a stable hash we need to have an ordered vision of the map.
 	keys := make([]string, 0, len(versionMap))
 	for key := range versionMap {
@@ -124,8 +124,8 @@ type ResponseWatch struct {
 	// Subscription stores the current client subscription state.
 	subscription Subscription
 
-	// enableStableVersion indicates whether versions returned in the response are built using stable versions instead of cache update versions.
-	enableStableVersion bool
+	// enableResourceVersion indicates whether versions returned in the response are built using stable versions instead of cache update versions.
+	enableResourceVersion bool
 
 	// fullStateResponses requires that all resources matching the request, with no regards to which ones actually updated, must be provided in the response.
 	fullStateResponses bool
@@ -145,8 +145,8 @@ func (w ResponseWatch) buildResponse(updatedResources []*cachedResource, _ []str
 	}
 }
 
-func (w ResponseWatch) useStableVersion() bool {
-	return w.enableStableVersion
+func (w ResponseWatch) useResourceVersion() bool {
+	return w.enableResourceVersion
 }
 
 func (w ResponseWatch) sendFullStateResponses() bool {
@@ -177,7 +177,7 @@ func (w DeltaResponseWatch) isDelta() bool {
 	return true
 }
 
-func (w DeltaResponseWatch) useStableVersion() bool {
+func (w DeltaResponseWatch) useResourceVersion() bool {
 	return true
 }
 

--- a/pkg/cache/v3/status.go
+++ b/pkg/cache/v3/status.go
@@ -135,7 +135,7 @@ func (w ResponseWatch) isDelta() bool {
 	return false
 }
 
-func (w ResponseWatch) buildResponse(updatedResources []cachedResource, _ []string, returnedVersions map[string]string, version string) WatchResponse {
+func (w ResponseWatch) buildResponse(updatedResources []*cachedResource, _ []string, returnedVersions map[string]string, version string) WatchResponse {
 	return &RawResponse{
 		Request:           w.Request,
 		resources:         updatedResources,
@@ -189,7 +189,7 @@ func (w DeltaResponseWatch) getSubscription() Subscription {
 	return w.subscription
 }
 
-func (w DeltaResponseWatch) buildResponse(updatedResources []cachedResource, removedResources []string, returnedVersions map[string]string, version string) WatchResponse {
+func (w DeltaResponseWatch) buildResponse(updatedResources []*cachedResource, removedResources []string, returnedVersions map[string]string, version string) WatchResponse {
 	return &RawDeltaResponse{
 		DeltaRequest:      w.Request,
 		resources:         updatedResources,

--- a/pkg/cache/v3/status.go
+++ b/pkg/cache/v3/status.go
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
-	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
 )
 
 // NodeHash computes string identifiers for Envoy nodes.
@@ -136,11 +135,11 @@ func (w ResponseWatch) isDelta() bool {
 	return false
 }
 
-func (w ResponseWatch) buildResponse(updatedResources []types.ResourceWithTTL, _ []string, returnedVersions map[string]string, version string) WatchResponse {
+func (w ResponseWatch) buildResponse(updatedResources []cachedResource, _ []string, returnedVersions map[string]string, version string) WatchResponse {
 	return &RawResponse{
 		Request:           w.Request,
-		Resources:         updatedResources,
-		ReturnedResources: returnedVersions,
+		resources:         updatedResources,
+		returnedResources: returnedVersions,
 		Version:           version,
 		Ctx:               context.Background(),
 	}
@@ -190,11 +189,11 @@ func (w DeltaResponseWatch) getSubscription() Subscription {
 	return w.subscription
 }
 
-func (w DeltaResponseWatch) buildResponse(updatedResources []types.ResourceWithTTL, removedResources []string, returnedVersions map[string]string, version string) WatchResponse {
+func (w DeltaResponseWatch) buildResponse(updatedResources []cachedResource, removedResources []string, returnedVersions map[string]string, version string) WatchResponse {
 	return &RawDeltaResponse{
 		DeltaRequest:      w.Request,
-		Resources:         updatedResources,
-		RemovedResources:  removedResources,
+		resources:         updatedResources,
+		removedResources:  removedResources,
 		NextVersionMap:    returnedVersions,
 		SystemVersionInfo: version,
 		Ctx:               context.Background(),

--- a/pkg/cache/v3/status.go
+++ b/pkg/cache/v3/status.go
@@ -194,7 +194,7 @@ func (w DeltaResponseWatch) buildResponse(updatedResources []cachedResource, rem
 		DeltaRequest:      w.Request,
 		resources:         updatedResources,
 		removedResources:  removedResources,
-		NextVersionMap:    returnedVersions,
+		nextVersionMap:    returnedVersions,
 		SystemVersionInfo: version,
 		Ctx:               context.Background(),
 	}

--- a/pkg/server/sotw/v3/ads.go
+++ b/pkg/server/sotw/v3/ads.go
@@ -49,7 +49,7 @@ func (s *server) processADS(sw *streamWrapper, reqCh chan *discovery.DiscoveryRe
 		// We only watch the multiplexed channel since we don't use per watch channels.
 		case res := <-respChan:
 			if err := sw.send(res); err != nil {
-				return status.Errorf(codes.Unavailable, err.Error())
+				return status.Error(codes.Unavailable, err.Error())
 			}
 		case req, ok := <-reqCh:
 			// Input stream ended or failed.

--- a/pkg/server/v3/delta_test.go
+++ b/pkg/server/v3/delta_test.go
@@ -79,13 +79,13 @@ func (config *mockConfigWatcher) CreateDeltaWatch(req *discovery.DeltaDiscoveryR
 	}
 
 	if len(filtered)+len(toRemove) > 0 {
-		out <- &cache.RawDeltaResponse{
-			DeltaRequest:      req,
-			Resources:         filtered,
-			RemovedResources:  toRemove,
-			SystemVersionInfo: "",
-			NextVersionMap:    nextVersionMap,
-		}
+		out <- cache.NewTestRawDeltaResponse(
+			req,
+			"",
+			filtered,
+			toRemove,
+			nextVersionMap,
+		)
 	} else {
 		config.deltaWatches++
 		return func() {

--- a/pkg/server/v3/gateway_test.go
+++ b/pkg/server/v3/gateway_test.go
@@ -33,25 +33,25 @@ func TestGateway(t *testing.T) {
 	config := makeMockConfigWatcher()
 	config.responses = map[string][]cache.Response{
 		resource.ClusterType: {
-			&cache.RawResponse{
-				Version:   "2",
-				Resources: []types.ResourceWithTTL{{Resource: cluster}},
-				Request:   &discovery.DiscoveryRequest{TypeUrl: resource.ClusterType},
-			},
+			cache.NewTestRawResponse(
+				&discovery.DiscoveryRequest{TypeUrl: resource.ClusterType},
+				"2",
+				[]types.ResourceWithTTL{{Resource: cluster}},
+			),
 		},
 		resource.RouteType: {
-			&cache.RawResponse{
-				Version:   "3",
-				Resources: []types.ResourceWithTTL{{Resource: route}},
-				Request:   &discovery.DiscoveryRequest{TypeUrl: resource.RouteType},
-			},
+			cache.NewTestRawResponse(
+				&discovery.DiscoveryRequest{TypeUrl: resource.RouteType},
+				"3",
+				[]types.ResourceWithTTL{{Resource: route}},
+			),
 		},
 		resource.ListenerType: {
-			&cache.RawResponse{
-				Version:   "4",
-				Resources: []types.ResourceWithTTL{{Resource: httpListener}, {Resource: httpScopedListener}},
-				Request:   &discovery.DiscoveryRequest{TypeUrl: resource.ListenerType},
-			},
+			cache.NewTestRawResponse(
+				&discovery.DiscoveryRequest{TypeUrl: resource.ListenerType},
+				"4",
+				[]types.ResourceWithTTL{{Resource: httpListener}, {Resource: httpScopedListener}},
+			),
 		},
 	}
 	gtw := server.HTTPGateway{Server: server.NewServer(context.Background(), config, nil)}

--- a/pkg/server/v3/server_test.go
+++ b/pkg/server/v3/server_test.go
@@ -188,75 +188,75 @@ var (
 func makeResponses() map[string][]cache.Response {
 	return map[string][]cache.Response{
 		rsrc.EndpointType: {
-			&cache.RawResponse{
-				Version:   "1",
-				Resources: []types.ResourceWithTTL{{Resource: endpoint}},
-				Request:   &discovery.DiscoveryRequest{TypeUrl: rsrc.EndpointType},
-			},
+			cache.NewTestRawResponse(
+				&discovery.DiscoveryRequest{TypeUrl: rsrc.EndpointType},
+				"1",
+				[]types.ResourceWithTTL{{Resource: endpoint}},
+			),
 		},
 		rsrc.ClusterType: {
-			&cache.RawResponse{
-				Version:   "2",
-				Resources: []types.ResourceWithTTL{{Resource: cluster}},
-				Request:   &discovery.DiscoveryRequest{TypeUrl: rsrc.ClusterType},
-			},
+			cache.NewTestRawResponse(
+				&discovery.DiscoveryRequest{TypeUrl: rsrc.ClusterType},
+				"2",
+				[]types.ResourceWithTTL{{Resource: cluster}},
+			),
 		},
 		rsrc.RouteType: {
-			&cache.RawResponse{
-				Version:   "3",
-				Resources: []types.ResourceWithTTL{{Resource: route}},
-				Request:   &discovery.DiscoveryRequest{TypeUrl: rsrc.RouteType},
-			},
+			cache.NewTestRawResponse(
+				&discovery.DiscoveryRequest{TypeUrl: rsrc.RouteType},
+				"3",
+				[]types.ResourceWithTTL{{Resource: route}},
+			),
 		},
 		rsrc.ScopedRouteType: {
-			&cache.RawResponse{
-				Version:   "4",
-				Resources: []types.ResourceWithTTL{{Resource: scopedRoute}},
-				Request:   &discovery.DiscoveryRequest{TypeUrl: rsrc.ScopedRouteType},
-			},
+			cache.NewTestRawResponse(
+				&discovery.DiscoveryRequest{TypeUrl: rsrc.ScopedRouteType},
+				"4",
+				[]types.ResourceWithTTL{{Resource: scopedRoute}},
+			),
 		},
 		rsrc.VirtualHostType: {
-			&cache.RawResponse{
-				Version:   "5",
-				Resources: []types.ResourceWithTTL{{Resource: virtualHost}},
-				Request:   &discovery.DiscoveryRequest{TypeUrl: rsrc.VirtualHostType},
-			},
+			cache.NewTestRawResponse(
+				&discovery.DiscoveryRequest{TypeUrl: rsrc.VirtualHostType},
+				"5",
+				[]types.ResourceWithTTL{{Resource: virtualHost}},
+			),
 		},
 		rsrc.ListenerType: {
-			&cache.RawResponse{
-				Version:   "6",
-				Resources: []types.ResourceWithTTL{{Resource: httpListener}, {Resource: httpScopedListener}},
-				Request:   &discovery.DiscoveryRequest{TypeUrl: rsrc.ListenerType},
-			},
+			cache.NewTestRawResponse(
+				&discovery.DiscoveryRequest{TypeUrl: rsrc.ListenerType},
+				"6",
+				[]types.ResourceWithTTL{{Resource: httpListener}, {Resource: httpScopedListener}},
+			),
 		},
 		rsrc.SecretType: {
-			&cache.RawResponse{
-				Version:   "7",
-				Resources: []types.ResourceWithTTL{{Resource: secret}},
-				Request:   &discovery.DiscoveryRequest{TypeUrl: rsrc.SecretType},
-			},
+			cache.NewTestRawResponse(
+				&discovery.DiscoveryRequest{TypeUrl: rsrc.SecretType},
+				"7",
+				[]types.ResourceWithTTL{{Resource: secret}},
+			),
 		},
 		rsrc.RuntimeType: {
-			&cache.RawResponse{
-				Version:   "8",
-				Resources: []types.ResourceWithTTL{{Resource: runtime}},
-				Request:   &discovery.DiscoveryRequest{TypeUrl: rsrc.RuntimeType},
-			},
+			cache.NewTestRawResponse(
+				&discovery.DiscoveryRequest{TypeUrl: rsrc.RuntimeType},
+				"8",
+				[]types.ResourceWithTTL{{Resource: runtime}},
+			),
 		},
 		rsrc.ExtensionConfigType: {
-			&cache.RawResponse{
-				Version:   "9",
-				Resources: []types.ResourceWithTTL{{Resource: extensionConfig}},
-				Request:   &discovery.DiscoveryRequest{TypeUrl: rsrc.ExtensionConfigType},
-			},
+			cache.NewTestRawResponse(
+				&discovery.DiscoveryRequest{TypeUrl: rsrc.ExtensionConfigType},
+				"9",
+				[]types.ResourceWithTTL{{Resource: extensionConfig}},
+			),
 		},
 		// Pass-through type (xDS does not exist for this type)
 		opaqueType: {
-			&cache.RawResponse{
-				Version:   "10",
-				Resources: []types.ResourceWithTTL{{Resource: opaque}},
-				Request:   &discovery.DiscoveryRequest{TypeUrl: opaqueType},
-			},
+			cache.NewTestRawResponse(
+				&discovery.DiscoveryRequest{TypeUrl: opaqueType},
+				"10",
+				[]types.ResourceWithTTL{{Resource: opaque}},
+			),
 		},
 	}
 }


### PR DESCRIPTION
Currently the go-control-plane caches (both linear and snapshots) will serialize the resource as many time as there are clients receiving it.
This is an issue with control-planes watched by a lot of clients, especially with large resources (e.g. endpoints)

This PR ensures that the serialization occurs at most once per resource, in all cases (sotw/delta watches and linear/snapshot cache). A resource will still only be serialized if:
 - it is returned to at least one client.
 - its version had to be considered to be returned (i.e. the resource was added again with the same stable version). 