### PR TITLE
Linear Cache Wildcard Support

### DIFF
--- a/pkg/cache/types/types.go
+++ b/pkg/cache/types/types.go
@@ -1,3 +1,4 @@
+//nolint:revive
 package types
 
 import (

--- a/pkg/cache/v3/cache.go
+++ b/pkg/cache/v3/cache.go
@@ -55,6 +55,11 @@ type Subscription interface {
 	// This considers subtleties related to the current migration of wildcard definitions within the protocol.
 	// More details on the behavior of wildcard are present at https://www.envoyproxy.io/docs/envoy/latest/api-docs/xds_protocol#how-the-client-specifies-what-resources-to-return
 	IsWildcard() bool
+
+	// The node id of the client
+	// For envoy client's it refers to the following node id
+	// https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/base.proto#config-core-v3-node
+	ClientNodeID() string
 }
 
 // ConfigWatcher requests watches for configuration resources by a node, last

--- a/pkg/cache/v3/delta_test.go
+++ b/pkg/cache/v3/delta_test.go
@@ -39,10 +39,11 @@ func TestSnapshotCacheDeltaWatch(t *testing.T) {
 	// Make our initial request as a wildcard to get all resources and make sure the wildcard requesting works as intended
 	for _, typ := range testTypes {
 		watches[typ] = make(chan cache.DeltaResponse, 1)
-		subscriptions[typ] = stream.NewDeltaSubscription(nil, nil, nil)
+		nodeID := "node"
+		subscriptions[typ] = stream.NewDeltaSubscription(nil, nil, nil, nodeID)
 		_, err := c.CreateDeltaWatch(&discovery.DeltaDiscoveryRequest{
 			Node: &core.Node{
-				Id: "node",
+				Id: nodeID,
 			},
 			TypeUrl: typ,
 		}, subscriptions[typ], watches[typ])
@@ -120,13 +121,14 @@ func TestDeltaRemoveResources(t *testing.T) {
 
 	for _, typ := range testTypes {
 		watches[typ] = make(chan cache.DeltaResponse, 1)
-		sub := stream.NewDeltaSubscription(nil, nil, nil)
+		nodeID := "node"
+		sub := stream.NewDeltaSubscription(nil, nil, nil, nodeID)
 		subscriptions[typ] = &sub
 		// We don't specify any resource name subscriptions here because we want to make sure we test wildcard
 		// functionality. This means we should receive all resources back without requesting a subscription by name.
 		_, err := c.CreateDeltaWatch(&discovery.DeltaDiscoveryRequest{
 			Node: &core.Node{
-				Id: "node",
+				Id: nodeID,
 			},
 			TypeUrl: typ,
 		}, *subscriptions[typ], watches[typ])
@@ -210,7 +212,7 @@ func TestConcurrentSetDeltaWatch(t *testing.T) {
 						},
 						TypeUrl:                rsrc.EndpointType,
 						ResourceNamesSubscribe: []string{clusterName},
-					}, stream.NewDeltaSubscription([]string{clusterName}, nil, nil), responses)
+					}, stream.NewDeltaSubscription([]string{clusterName}, nil, nil, id), responses)
 
 					require.NoError(t, err)
 					defer cancel()
@@ -227,7 +229,7 @@ func TestSnapshotDeltaCacheWatchTimeout(t *testing.T) {
 
 	// Create a non-buffered channel that will block sends.
 	watchCh := make(chan cache.DeltaResponse)
-	sub := stream.NewDeltaSubscription(names[rsrc.EndpointType], nil, nil)
+	sub := stream.NewDeltaSubscription(names[rsrc.EndpointType], nil, nil, key)
 	_, err := c.CreateDeltaWatch(&discovery.DeltaDiscoveryRequest{
 		Node: &core.Node{
 			Id: key,
@@ -277,7 +279,7 @@ func TestSnapshotCacheDeltaWatchCancel(t *testing.T) {
 			},
 			TypeUrl:                typ,
 			ResourceNamesSubscribe: names[typ],
-		}, stream.NewDeltaSubscription(names[typ], nil, nil), responses)
+		}, stream.NewDeltaSubscription(names[typ], nil, nil, key), responses)
 		require.NoError(t, err)
 
 		// Cancel the watch

--- a/pkg/cache/v3/linear.go
+++ b/pkg/cache/v3/linear.go
@@ -136,10 +136,11 @@ type LinearCache struct {
 	currentWatchID uint64
 
 	// explicitWildcardResourcesPerNode stores the set of resources to return for each node's wildcard subscriptions
-	// when useExplicitWildcardResources mode is enabled (via WithExplicitWildcardResources option).
+	// when useExplicitWildcardResources mode is enabled.
 	// The outer map is keyed by node ID (string), and the inner map contains resource names (string) as a set.
-	// This allows customizing which resources are visible to each client node for wildcard requests,
-	// instead of returning all resources in the cache via the UpdateWilcardResourcesForNode() method.
+	// This allows customizing which resources are visible to each client node for wildcard requests
+	// instead of returning all resources in the cache. This mapping is set via
+	// the UpdateWilcardResourcesForNode() method.
 	explicitWildcardResourcesPerNode map[string]map[string]struct{}
 
 	// version is the current version of the cache. It is incremented each time resources are updated.

--- a/pkg/cache/v3/linear.go
+++ b/pkg/cache/v3/linear.go
@@ -135,6 +135,13 @@ type LinearCache struct {
 	// currentWatchID is used to index new watches.
 	currentWatchID uint64
 
+	// explicitWildcardResourcesPerNode stores the set of resources to return for each node's wildcard subscriptions
+	// when useExplicitWildcardResources mode is enabled (via WithExplicitWildcardResources option).
+	// The outer map is keyed by node ID (string), and the inner map contains resource names (string) as a set.
+	// This allows customizing which resources are visible to each client node for wildcard requests,
+	// instead of returning all resources in the cache via the UpdateWilcardResourcesForNode() method.
+	explicitWildcardResourcesPerNode map[string]map[string]struct{}
+
 	// version is the current version of the cache. It is incremented each time resources are updated.
 	version uint64
 	// versionPrefix is used to modify the version returned to clients, and can be used to uniquely identify
@@ -146,6 +153,11 @@ type LinearCache struct {
 	// is a hash of the returned versions to allow watch resumptions when reconnecting to the cache with a
 	// new subscription.
 	useResourceVersionsInSotw bool
+
+	// useExplicitWildcardResources enables explicit wildcard mode where wildcard subscriptions only return
+	// resources explicitly configured per-node via UpdateWilcardResourcesForNode() instead of all resources.
+	// When disabled (default), wildcard subscriptions return all resources in the cache.
+	useExplicitWildcardResources bool
 
 	watchCount int
 
@@ -197,6 +209,16 @@ func WithSotwResourceVersions() LinearCacheOption {
 	}
 }
 
+// WithCustomWildcardMode informs the cache to reply to wildcard requests based on the
+// list of resources explicitly set by the user instead of the default behavior of all resources
+// The list of resouces are set with the method 'UpdateWilcardResourcesForNode'.
+func WithExplicitWildcardResources() LinearCacheOption {
+	return func(cache *LinearCache) {
+		cache.useExplicitWildcardResources = true
+		cache.explicitWildcardResourcesPerNode = make(map[string]map[string]struct{})
+	}
+}
+
 // NewLinearCache creates a new cache. See the comments on the struct definition.
 func NewLinearCache(typeURL string, opts ...LinearCacheOption) *LinearCache {
 	out := &LinearCache{
@@ -218,6 +240,42 @@ func NewLinearCache(typeURL string, opts ...LinearCacheOption) *LinearCache {
 	return out
 }
 
+func computeResourceChangeForWildcardSubscription(
+	resources map[string]*cachedResource,
+	knownVersions map[string]string,
+	changedResources,
+	removedResources []string,
+	useResourceVersion bool,
+) ([]string, []string, error) {
+	for resourceName, resource := range resources {
+		knownVersion, ok := knownVersions[resourceName]
+		if !ok {
+			// This resource is not yet known by the client (new resource added in the cache or newly subscribed).
+			changedResources = append(changedResources, resourceName)
+		} else {
+			resourceVersion, err := resource.getVersion(useResourceVersion)
+			if err != nil {
+				return nil, nil, fmt.Errorf("failed to compute version of %s: %w", resourceName, err)
+			}
+			if knownVersion != resourceVersion {
+				// The client knows an outdated version.
+				changedResources = append(changedResources, resourceName)
+			}
+		}
+	}
+
+	// Negative check to identify resources that have been removed in the cache.
+	// Sotw does not support returning "deletions", but in the case of full state resources
+	// a response must then be returned.
+	for resourceName := range knownVersions {
+		if _, ok := resources[resourceName]; !ok {
+			removedResources = append(removedResources, resourceName)
+		}
+	}
+
+	return changedResources, removedResources, nil
+}
+
 // computeResourceChange compares the subscription known resources and the cache current state to compute the list of resources
 // which have changed and should be notified to the user.
 //
@@ -230,30 +288,29 @@ func (cache *LinearCache) computeResourceChange(sub Subscription, useResourceVer
 
 	knownVersions := sub.ReturnedResources()
 	if sub.IsWildcard() {
-		for resourceName, resource := range cache.resources {
-			knownVersion, ok := knownVersions[resourceName]
-			if !ok {
-				// This resource is not yet known by the client (new resource added in the cache or newly subscribed).
-				changedResources = append(changedResources, resourceName)
-			} else {
-				resourceVersion, err := resource.getVersion(useResourceVersion)
-				if err != nil {
-					return nil, nil, fmt.Errorf("failed to compute version of %s: %w", resourceName, err)
-				}
-				if knownVersion != resourceVersion {
-					// The client knows an outdated version.
-					changedResources = append(changedResources, resourceName)
+		var resources map[string]*cachedResource
+		if cache.useExplicitWildcardResources {
+			// only includes resources that have been explicitly set for this node, that also
+			// exist in our cache
+			resources = make(map[string]*cachedResource)
+			for resourceName := range cache.explicitWildcardResourcesPerNode[sub.ClientNodeID()] {
+				if resource, ok := cache.resources[resourceName]; ok {
+					resources[resourceName] = resource
 				}
 			}
+		} else {
+			resources = cache.resources
 		}
 
-		// Negative check to identify resources that have been removed in the cache.
-		// Sotw does not support returning "deletions", but in the case of full state resources
-		// a response must then be returned.
-		for resourceName := range knownVersions {
-			if _, ok := cache.resources[resourceName]; !ok {
-				removedResources = append(removedResources, resourceName)
-			}
+		var err error
+		changedResources, removedResources, err = computeResourceChangeForWildcardSubscription(
+			resources, knownVersions, changedResources, removedResources, useResourceVersion)
+		if err != nil {
+			return nil, nil, fmt.Errorf(
+				"failed to compute resource changes for wildcard subscription(explicit wildcard mode is %t): %w",
+				cache.useExplicitWildcardResources,
+				err,
+			)
 		}
 	} else {
 		for resourceName := range sub.SubscribedResources() {
@@ -327,10 +384,20 @@ func (cache *LinearCache) computeResponse(watch watch, replyEvenIfEmpty bool) (W
 		// changedResources is already filtered based on the subscription.
 		resourcesToReturn = changedResources
 	case sub.IsWildcard():
-		// Include all resources for the type.
 		resourcesToReturn = make([]string, 0, len(cache.resources))
-		for resourceName := range cache.resources {
-			resourcesToReturn = append(resourcesToReturn, resourceName)
+
+		if cache.useExplicitWildcardResources {
+			// Only return wildcard resources set for this node, that are also present in the cache.
+			for resourceName := range cache.explicitWildcardResourcesPerNode[sub.ClientNodeID()] {
+				if _, ok := cache.resources[resourceName]; ok {
+					resourcesToReturn = append(resourcesToReturn, resourceName)
+				}
+			}
+		} else {
+			// Include all resources for the type.
+			for resourceName := range cache.resources {
+				resourcesToReturn = append(resourcesToReturn, resourceName)
+			}
 		}
 	default:
 		// Include all resources matching the subscription, with no concern on whether it has been updated or not.
@@ -418,6 +485,28 @@ func (cache *LinearCache) notifyAll(modified []string) error {
 	return nil
 }
 
+func (cache *LinearCache) notifyNode(nodeID string) error {
+	for watchID, watch := range cache.wildcardWatches {
+		if watch.getSubscription().ClientNodeID() != nodeID {
+			continue
+		}
+
+		response, err := cache.computeResponse(watch, false)
+		if err != nil {
+			return err
+		}
+
+		if response != nil {
+			watch.sendResponse(response)
+			cache.removeWildcardWatch(watchID)
+		} else {
+			cache.log.Infof("[Linear cache] Wildcard watch %d detected as triggered but no change was found", watchID)
+		}
+	}
+
+	return nil
+}
+
 // UpdateResource updates a resource in the collection.
 func (cache *LinearCache) UpdateResource(name string, res types.Resource) error {
 	if res == nil {
@@ -430,6 +519,28 @@ func (cache *LinearCache) UpdateResource(name string, res types.Resource) error 
 	cache.resources[name] = newCachedResource(name, res, cache.getVersion())
 
 	return cache.notifyAll([]string{name})
+}
+
+// UpdateWilcardResourcesForNode updates the list of resources
+// returned for a given client node id when using wildcard subscriptions.
+// To use this method the 'WithExplicitWildcardResources' option must be set
+// on the cache.
+func (cache *LinearCache) UpdateWilcardResourcesForNode(
+	nodeID string,
+	resourceNames map[string]struct{},
+) error {
+	if !cache.useExplicitWildcardResources {
+		return errors.New(
+			"in order to use 'UpdateWilcardResourcesForNode', the 'WithExplicitWildcardResources' option must be set")
+	}
+
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
+
+	cache.version++
+	cache.explicitWildcardResourcesPerNode[nodeID] = resourceNames
+
+	return cache.notifyNode(nodeID)
 }
 
 // DeleteResource removes a resource in the collection.

--- a/pkg/cache/v3/linear_explicit_wildcard_test.go
+++ b/pkg/cache/v3/linear_explicit_wildcard_test.go
@@ -1,0 +1,596 @@
+// Copyright 2020 Envoyproxy Authors
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+package cache
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	endpoint "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
+	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
+	"github.com/envoyproxy/go-control-plane/pkg/log"
+	"github.com/envoyproxy/go-control-plane/pkg/resource/v3"
+	"github.com/envoyproxy/go-control-plane/pkg/server/stream/v3"
+)
+
+const (
+	node1            = "test-node-1"
+	node2            = "test-node-2"
+	wildcardTestType = resource.EndpointType
+)
+
+func buildTestEndpoint(name string) types.Resource {
+	return &endpoint.ClusterLoadAssignment{
+		ClusterName: name,
+		Endpoints: []*endpoint.LocalityLbEndpoints{{
+			Locality: &core.Locality{Zone: "zone-" + name},
+			LbEndpoints: []*endpoint.LbEndpoint{{
+				HostIdentifier: &endpoint.LbEndpoint_Endpoint{
+					Endpoint: &endpoint.Endpoint{
+						Address: &core.Address{
+							Address: &core.Address_SocketAddress{
+								SocketAddress: &core.SocketAddress{
+									Protocol: core.SocketAddress_TCP,
+									Address:  "127.0.0.1",
+									PortSpecifier: &core.SocketAddress_PortValue{
+										PortValue: 8080,
+									},
+								},
+							},
+						},
+					},
+				},
+			}},
+		}},
+	}
+}
+
+func newExplicitWildcardCache(t *testing.T) *LinearCache {
+	t.Helper()
+	return NewLinearCache(wildcardTestType,
+		WithExplicitWildcardResources(),
+		WithLogger(log.NewTestLogger(t)))
+}
+
+func setExplicitResources(t *testing.T, c *LinearCache, nodeID string, resources ...string) {
+	t.Helper()
+	resourceMap := make(map[string]struct{}, len(resources))
+	for _, r := range resources {
+		resourceMap[r] = struct{}{}
+	}
+	err := c.UpdateWilcardResourcesForNode(nodeID, resourceMap)
+	require.NoError(t, err)
+}
+
+func createNodeWildcardWatch(t *testing.T, c *LinearCache, nodeID string) (<-chan Response, stream.Subscription) {
+	t.Helper()
+	req := &Request{ResourceNames: []string{"*"}, TypeUrl: wildcardTestType}
+	sub := stream.NewSotwSubscription(nil, nodeID)
+	w := make(chan Response, 1)
+	_, err := c.CreateWatch(req, sub, w)
+	require.NoError(t, err)
+	return w, sub
+}
+
+//nolint:unparam
+func createNodeWildcardDeltaWatch(t *testing.T, c *LinearCache, nodeID string) (<-chan DeltaResponse, stream.Subscription) {
+	t.Helper()
+	req := &DeltaRequest{
+		TypeUrl:                wildcardTestType,
+		ResourceNamesSubscribe: []string{"*"},
+	}
+	sub := stream.NewDeltaSubscription(
+		nil, nil, nil, nodeID,
+	)
+	w := make(chan DeltaResponse, 1)
+	_, err := c.CreateDeltaWatch(req, sub, w)
+	require.NoError(t, err)
+	return w, sub
+}
+
+type protocolTest struct {
+	name            string
+	createWatch     func(t *testing.T, c *LinearCache, nodeID, versionInfo string) (stream.Subscription, any)
+	verifyEmpty     func(t *testing.T, respCh any, expectedVersion string)
+	verifyResources func(t *testing.T, respCh any, expectedVersion string, resources ...string)
+	mustBlock       func(t *testing.T, respCh any)
+}
+
+func getProtocolTests() []protocolTest {
+	return []protocolTest{
+		{
+			name: "SOTW",
+			createWatch: func(t *testing.T, c *LinearCache, nodeID, _ string) (stream.Subscription, any) {
+				t.Helper()
+				req := &Request{ResourceNames: []string{"*"}, TypeUrl: wildcardTestType, VersionInfo: ""}
+				sub := stream.NewSotwSubscription(req.GetResourceNames(), nodeID)
+				w := make(chan Response, 1)
+				_, err := c.CreateWatch(req, sub, w)
+				require.NoError(t, err)
+				return sub, w
+			},
+			verifyEmpty: func(t *testing.T, respCh any, _ string) {
+				t.Helper()
+				w, ok := respCh.(chan Response)
+				require.True(t, ok, "failed to cast to SOTW response channel")
+				verifyResponseResources(t, w, wildcardTestType, "")
+			},
+			verifyResources: func(t *testing.T, respCh any, _ string, resources ...string) {
+				t.Helper()
+				w, ok := respCh.(chan Response)
+				require.True(t, ok, "failed to cast to SOTW response channel")
+				verifyResponseResources(t, w, wildcardTestType, "", resources...)
+			},
+			mustBlock: func(t *testing.T, respCh any) {
+				t.Helper()
+				w, ok := respCh.(chan Response)
+				require.True(t, ok, "failed to cast to SOTW response channel")
+				mustBlock(t, w)
+			},
+		},
+		{
+			name: "Delta",
+			createWatch: func(t *testing.T, c *LinearCache, nodeID, _ string) (stream.Subscription, any) {
+				t.Helper()
+				req := &DeltaRequest{TypeUrl: wildcardTestType, ResourceNamesSubscribe: []string{"*"}}
+				sub := stream.NewDeltaSubscription(req.GetResourceNamesSubscribe(), req.GetResourceNamesUnsubscribe(), req.GetInitialResourceVersions(), nodeID)
+				w := make(chan DeltaResponse, 1)
+				_, err := c.CreateDeltaWatch(req, sub, w)
+				require.NoError(t, err)
+				return sub, w
+			},
+			verifyEmpty: func(t *testing.T, respCh any, _ string) {
+				t.Helper()
+				w, ok := respCh.(chan DeltaResponse)
+				require.True(t, ok, "failed to cast to Delta response channel")
+				resp := <-w
+				assert.Empty(t, resp.GetNextVersionMap())
+			},
+			verifyResources: func(t *testing.T, respCh any, _ string, resources ...string) {
+				t.Helper()
+				w, ok := respCh.(chan DeltaResponse)
+				require.True(t, ok, "failed to cast to Delta response channel")
+				resp := <-w
+				versionMap := resp.GetNextVersionMap()
+				assert.Len(t, versionMap, len(resources))
+				for _, r := range resources {
+					assert.Contains(t, versionMap, r)
+				}
+			},
+			mustBlock: func(t *testing.T, respCh any) {
+				t.Helper()
+				w, ok := respCh.(chan DeltaResponse)
+				require.True(t, ok, "failed to cast to Delta response channel")
+				mustBlockDelta(t, w)
+			},
+		},
+	}
+}
+
+func TestLinearExplicitWildcardBothProtocols(t *testing.T) {
+	protocols := getProtocolTests()
+
+	for _, protocol := range protocols {
+		t.Run(protocol.name, func(t *testing.T) {
+			t.Run("handles empty resource list", func(t *testing.T) {
+				c := newExplicitWildcardCache(t)
+
+				require.NoError(t, c.UpdateResource("a", buildTestEndpoint("a")))
+				setExplicitResources(t, c, node1)
+
+				_, w := protocol.createWatch(t, c, node1, "")
+				protocol.verifyEmpty(t, w, "")
+			})
+
+			t.Run("multiple nodes with different explicit resources", func(t *testing.T) {
+				c := newExplicitWildcardCache(t)
+
+				require.NoError(t, c.UpdateResource("a", buildTestEndpoint("a")))
+				require.NoError(t, c.UpdateResource("b", buildTestEndpoint("b")))
+				require.NoError(t, c.UpdateResource("c", buildTestEndpoint("c")))
+
+				setExplicitResources(t, c, node1, "a", "b")
+				setExplicitResources(t, c, node2, "b", "c")
+
+				_, w1 := protocol.createWatch(t, c, node1, "")
+				_, w2 := protocol.createWatch(t, c, node2, "")
+
+				protocol.verifyResources(t, w1, "", "a", "b")
+				protocol.verifyResources(t, w2, "", "b", "c")
+			})
+
+			t.Run("explicit resource not in cache", func(t *testing.T) {
+				c := newExplicitWildcardCache(t)
+
+				require.NoError(t, c.UpdateResource("a", buildTestEndpoint("a")))
+				require.NoError(t, c.UpdateResource("b", buildTestEndpoint("b")))
+
+				setExplicitResources(t, c, node1, "a", "b", "nonexistent")
+
+				_, w := protocol.createWatch(t, c, node1, "")
+				protocol.verifyResources(t, w, "", "a", "b")
+			})
+		})
+	}
+}
+
+func TestLinearUpdateWildcardResourcesForNode(t *testing.T) {
+	t.Run("triggers pending wildcard watches", func(t *testing.T) {
+		c := newExplicitWildcardCache(t)
+
+		require.NoError(t, c.UpdateResource("a", buildTestEndpoint("a")))
+		require.NoError(t, c.UpdateResource("b", buildTestEndpoint("b")))
+
+		req := &Request{
+			ResourceNames: []string{"*"},
+			TypeUrl:       wildcardTestType,
+			VersionInfo:   "",
+		}
+		sub := stream.NewSotwSubscription(req.GetResourceNames(), node1)
+		w := make(chan Response, 1)
+		_, err := c.CreateWatch(req, sub, w)
+		require.NoError(t, err)
+
+		resp, r := verifyResponseContent(t, w, wildcardTestType, "2")
+		assert.Empty(t, r.GetResources())
+		updateFromSotwResponse(resp, &sub, req)
+
+		w2 := make(chan Response, 1)
+		_, err = c.CreateWatch(req, sub, w2)
+		require.NoError(t, err)
+		mustBlock(t, w2)
+
+		setExplicitResources(t, c, node1, "a", "b")
+		verifyResponseResources(t, w2, wildcardTestType, "3", "a", "b")
+	})
+
+	t.Run("only notifies watches for specified node", func(t *testing.T) {
+		c := newExplicitWildcardCache(t)
+
+		require.NoError(t, c.UpdateResource("a", buildTestEndpoint("a")))
+
+		req1 := &Request{
+			ResourceNames: []string{"*"},
+			TypeUrl:       wildcardTestType,
+			VersionInfo:   "",
+		}
+		req2 := &Request{
+			ResourceNames: []string{"*"},
+			TypeUrl:       wildcardTestType,
+			VersionInfo:   "",
+		}
+		sub1 := stream.NewSotwSubscription(req1.GetResourceNames(), node1)
+		sub2 := stream.NewSotwSubscription(req2.GetResourceNames(), node2)
+		w1 := make(chan Response, 1)
+		w2 := make(chan Response, 1)
+
+		_, err := c.CreateWatch(req1, sub1, w1)
+		require.NoError(t, err)
+		_, err = c.CreateWatch(req2, sub2, w2)
+		require.NoError(t, err)
+
+		resp1, r1 := verifyResponseContent(t, w1, wildcardTestType, "1")
+		assert.Empty(t, r1.GetResources())
+		resp2, r2 := verifyResponseContent(t, w2, wildcardTestType, "1")
+		assert.Empty(t, r2.GetResources())
+		updateFromSotwResponse(resp1, &sub1, req1)
+		updateFromSotwResponse(resp2, &sub2, req2)
+
+		req1.VersionInfo = "1"
+		req2.VersionInfo = "1"
+
+		w1Next := make(chan Response, 1)
+		_, err = c.CreateWatch(req1, sub1, w1Next)
+		require.NoError(t, err)
+
+		w2Next := make(chan Response, 1)
+		_, err = c.CreateWatch(req2, sub2, w2Next)
+		require.NoError(t, err)
+
+		mustBlock(t, w1Next)
+		mustBlock(t, w2Next)
+
+		setExplicitResources(t, c, node1, "a")
+		verifyResponseResources(t, w1Next, wildcardTestType, "2", "a")
+		mustBlock(t, w2Next)
+	})
+
+	t.Run("handles empty resource list", func(t *testing.T) {
+		c := newExplicitWildcardCache(t)
+
+		require.NoError(t, c.UpdateResource("a", buildTestEndpoint("a")))
+
+		setExplicitResources(t, c, node1)
+
+		w, _ := createNodeWildcardWatch(t, c, node1)
+		verifyResponseResources(t, w, wildcardTestType, "")
+	})
+}
+
+func TestLinearExplicitWildcardErrors(t *testing.T) {
+	t.Run("UpdateWilcardResourcesForNode without mode enabled", func(t *testing.T) {
+		c := NewLinearCache(wildcardTestType, WithLogger(log.NewTestLogger(t)))
+
+		resourceMap := map[string]struct{}{"a": {}}
+		err := c.UpdateWilcardResourcesForNode(node1, resourceMap)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "WithExplicitWildcardResources")
+	})
+}
+
+func TestLinearExplicitWildcardSotw(t *testing.T) {
+	t.Run("don't receive entire cache with explicit resources", func(t *testing.T) {
+		c := newExplicitWildcardCache(t)
+
+		require.NoError(t, c.UpdateResource("a", buildTestEndpoint("a")))
+		require.NoError(t, c.UpdateResource("b", buildTestEndpoint("b")))
+		require.NoError(t, c.UpdateResource("c", buildTestEndpoint("c")))
+
+		setExplicitResources(t, c, node1, "a", "b")
+
+		w, sub := createNodeWildcardWatch(t, c, node1)
+		resp := verifyResponseResources(t, w, wildcardTestType, "", "a", "b")
+
+		updateFromSotwResponse(resp, &sub, &Request{TypeUrl: wildcardTestType})
+
+		checkTotalWatchCount(t, c, 0)
+	})
+
+	t.Run("explicit resources updated while watch active", func(t *testing.T) {
+		c := newExplicitWildcardCache(t)
+
+		require.NoError(t, c.UpdateResource("a", buildTestEndpoint("a")))
+		require.NoError(t, c.UpdateResource("b", buildTestEndpoint("b")))
+		require.NoError(t, c.UpdateResource("c", buildTestEndpoint("c")))
+
+		setExplicitResources(t, c, node1, "a", "b")
+
+		w, sub := createNodeWildcardWatch(t, c, node1)
+		resp := verifyResponseResources(t, w, wildcardTestType, "", "a", "b")
+		version, _ := resp.GetVersion()
+		updateFromSotwResponse(resp, &sub, &Request{TypeUrl: wildcardTestType, VersionInfo: version})
+
+		w2 := make(chan Response, 1)
+		req := &Request{
+			ResourceNames: []string{"*"},
+			TypeUrl:       wildcardTestType,
+			VersionInfo:   version,
+		}
+		_, err := c.CreateWatch(req, sub, w2)
+		require.NoError(t, err)
+		mustBlock(t, w2)
+
+		setExplicitResources(t, c, node1, "b", "c")
+		resp2 := <-w2
+		returnedResources := resp2.GetReturnedResources()
+		assert.Contains(t, returnedResources, "b")
+		assert.Contains(t, returnedResources, "c")
+	})
+}
+
+func TestLinearExplicitWildcardDelta(t *testing.T) {
+	t.Run("delta wildcard with explicit resources", func(t *testing.T) {
+		c := newExplicitWildcardCache(t)
+
+		require.NoError(t, c.UpdateResource("a", buildTestEndpoint("a")))
+		require.NoError(t, c.UpdateResource("b", buildTestEndpoint("b")))
+		require.NoError(t, c.UpdateResource("c", buildTestEndpoint("c")))
+
+		setExplicitResources(t, c, node1, "a", "b")
+
+		w, sub := createNodeWildcardDeltaWatch(t, c, node1)
+		resp := <-w
+		nextVersionMap := resp.GetNextVersionMap()
+		sub.SetReturnedResources(nextVersionMap)
+
+		assert.Len(t, nextVersionMap, 2)
+		assert.Contains(t, nextVersionMap, "a")
+		assert.Contains(t, nextVersionMap, "b")
+
+		req := &DeltaRequest{
+			TypeUrl:       wildcardTestType,
+			ResponseNonce: "1",
+		}
+		w2 := make(chan DeltaResponse, 1)
+		_, err := c.CreateDeltaWatch(req, sub, w2)
+		require.NoError(t, err)
+		mustBlockDelta(t, w2)
+	})
+
+	t.Run("delta wildcard resource versions tracked correctly", func(t *testing.T) {
+		c := newExplicitWildcardCache(t)
+
+		require.NoError(t, c.UpdateResource("a", buildTestEndpoint("a")))
+		require.NoError(t, c.UpdateResource("b", buildTestEndpoint("b")))
+
+		setExplicitResources(t, c, node1, "a", "b")
+
+		w, sub := createNodeWildcardDeltaWatch(t, c, node1)
+		resp := <-w
+		sub.SetReturnedResources(resp.GetNextVersionMap())
+
+		req := &DeltaRequest{
+			TypeUrl:       wildcardTestType,
+			ResponseNonce: "1",
+		}
+		w2 := make(chan DeltaResponse, 1)
+		_, err := c.CreateDeltaWatch(req, sub, w2)
+		require.NoError(t, err)
+		mustBlockDelta(t, w2)
+
+		require.NoError(t, c.UpdateResource("a", buildTestEndpoint("a-updated")))
+		resp2 := <-w2
+		nextVersionMap2 := resp2.GetNextVersionMap()
+		assert.Len(t, nextVersionMap2, 2)
+		assert.Contains(t, nextVersionMap2, "a")
+	})
+
+	t.Run("delta wildcard with resource removal from explicit list", func(t *testing.T) {
+		c := newExplicitWildcardCache(t)
+
+		require.NoError(t, c.UpdateResource("a", buildTestEndpoint("a")))
+		require.NoError(t, c.UpdateResource("b", buildTestEndpoint("b")))
+		require.NoError(t, c.UpdateResource("c", buildTestEndpoint("c")))
+
+		setExplicitResources(t, c, node1, "a", "b", "c")
+
+		w, sub := createNodeWildcardDeltaWatch(t, c, node1)
+		resp := <-w
+		sub.SetReturnedResources(resp.GetNextVersionMap())
+
+		req := &DeltaRequest{
+			TypeUrl:       wildcardTestType,
+			ResponseNonce: "1",
+		}
+		w2 := make(chan DeltaResponse, 1)
+		_, err := c.CreateDeltaWatch(req, sub, w2)
+		require.NoError(t, err)
+		mustBlockDelta(t, w2)
+
+		setExplicitResources(t, c, node1, "a", "b")
+		resp2 := <-w2
+		deltaResp, err := resp2.GetDeltaDiscoveryResponse()
+		require.NoError(t, err)
+		removedResources := deltaResp.GetRemovedResources()
+		assert.Contains(t, removedResources, "c")
+	})
+
+	t.Run("delta wildcard update explicit list triggers watch", func(t *testing.T) {
+		c := newExplicitWildcardCache(t)
+
+		require.NoError(t, c.UpdateResource("a", buildTestEndpoint("a")))
+		require.NoError(t, c.UpdateResource("b", buildTestEndpoint("b")))
+		require.NoError(t, c.UpdateResource("c", buildTestEndpoint("c")))
+
+		setExplicitResources(t, c, node1, "a", "b")
+
+		w, sub := createNodeWildcardDeltaWatch(t, c, node1)
+		resp := <-w
+		sub.SetReturnedResources(resp.GetNextVersionMap())
+
+		req := &DeltaRequest{
+			TypeUrl:       wildcardTestType,
+			ResponseNonce: "1",
+		}
+		w2 := make(chan DeltaResponse, 1)
+		_, err := c.CreateDeltaWatch(req, sub, w2)
+		require.NoError(t, err)
+		mustBlockDelta(t, w2)
+
+		setExplicitResources(t, c, node1, "a", "c")
+		resp2 := <-w2
+		nextVersionMap2 := resp2.GetNextVersionMap()
+		deltaResp, err := resp2.GetDeltaDiscoveryResponse()
+		require.NoError(t, err)
+		removedResources := deltaResp.GetRemovedResources()
+		assert.Contains(t, nextVersionMap2, "c")
+		assert.Contains(t, removedResources, "b")
+	})
+}
+
+func TestLinearExplicitWildcardMixedSubscriptions(t *testing.T) {
+	t.Run("wildcard and non-wildcard watches coexist", func(t *testing.T) {
+		c := newExplicitWildcardCache(t)
+
+		require.NoError(t, c.UpdateResource("a", buildTestEndpoint("a")))
+		require.NoError(t, c.UpdateResource("b", buildTestEndpoint("b")))
+
+		setExplicitResources(t, c, node1, "a")
+
+		wWildcard, subWildcard := createNodeWildcardWatch(t, c, node1)
+		respWildcard := verifyResponseResources(t, wWildcard, wildcardTestType, "", "a")
+		updateFromSotwResponse(respWildcard, &subWildcard, &Request{TypeUrl: wildcardTestType})
+
+		reqNonWildcard := &Request{
+			ResourceNames: []string{"a", "b"},
+			TypeUrl:       wildcardTestType,
+			VersionInfo:   "",
+		}
+		wNonWildcard := make(chan Response, 1)
+		subNonWildcard := stream.NewSotwSubscription(reqNonWildcard.GetResourceNames(), node1)
+		_, err := c.CreateWatch(reqNonWildcard, subNonWildcard, wNonWildcard)
+		require.NoError(t, err)
+		verifyResponseResources(t, wNonWildcard, wildcardTestType, "", "a", "b")
+	})
+
+	t.Run("explicit wildcard only affects wildcard subscriptions", func(t *testing.T) {
+		c := newExplicitWildcardCache(t)
+
+		require.NoError(t, c.UpdateResource("a", buildTestEndpoint("a")))
+		require.NoError(t, c.UpdateResource("b", buildTestEndpoint("b")))
+
+		setExplicitResources(t, c, node1, "a")
+
+		req := &Request{
+			ResourceNames: []string{"b"},
+			TypeUrl:       wildcardTestType,
+			VersionInfo:   "",
+		}
+		w := make(chan Response, 1)
+		sub := stream.NewSotwSubscription(req.GetResourceNames(), node1)
+		_, err := c.CreateWatch(req, sub, w)
+		require.NoError(t, err)
+
+		verifyResponseResources(t, w, wildcardTestType, "", "b")
+	})
+
+	t.Run("cache update triggers correct watches", func(t *testing.T) {
+		c := newExplicitWildcardCache(t)
+
+		require.NoError(t, c.UpdateResource("a", buildTestEndpoint("a")))
+		require.NoError(t, c.UpdateResource("b", buildTestEndpoint("b")))
+
+		setExplicitResources(t, c, node1, "a")
+		setExplicitResources(t, c, node2, "b")
+
+		w1, sub1 := createNodeWildcardWatch(t, c, node1)
+		resp1 := verifyResponseResources(t, w1, wildcardTestType, "", "a")
+		version1, _ := resp1.GetVersion()
+		updateFromSotwResponse(resp1, &sub1, &Request{TypeUrl: wildcardTestType, VersionInfo: version1})
+
+		w2, sub2 := createNodeWildcardWatch(t, c, node2)
+		resp2 := verifyResponseResources(t, w2, wildcardTestType, "", "b")
+		version2, _ := resp2.GetVersion()
+		updateFromSotwResponse(resp2, &sub2, &Request{TypeUrl: wildcardTestType, VersionInfo: version2})
+
+		w1Next := make(chan Response, 1)
+		_, err := c.CreateWatch(&Request{
+			ResourceNames: []string{"*"},
+			TypeUrl:       wildcardTestType,
+			VersionInfo:   version1,
+		}, sub1, w1Next)
+		require.NoError(t, err)
+		mustBlock(t, w1Next)
+
+		w2Next := make(chan Response, 1)
+		_, err = c.CreateWatch(&Request{
+			ResourceNames: []string{"*"},
+			TypeUrl:       wildcardTestType,
+			VersionInfo:   version2,
+		}, sub2, w2Next)
+		require.NoError(t, err)
+		mustBlock(t, w2Next)
+
+		require.NoError(t, c.UpdateResource("a", buildTestEndpoint("a-updated")))
+
+		resp1Next := <-w1Next
+		assert.Contains(t, resp1Next.GetReturnedResources(), "a")
+		mustBlock(t, w2Next)
+	})
+}

--- a/pkg/cache/v3/linear_explicit_wildcard_test.go
+++ b/pkg/cache/v3/linear_explicit_wildcard_test.go
@@ -230,7 +230,7 @@ func getProtocolTests() []protocolTest {
 				if !ok {
 					panic("failed to cast to Delta response")
 				}
-				sub.SetReturnedResources(deltaResp.GetNextVersionMap())
+				sub.SetReturnedResources(deltaResp.GetReturnedResources())
 			},
 			createAdditionalWatch: func(t *testing.T, c *LinearCache, sub stream.Subscription, version string) any {
 				req := &DeltaRequest{
@@ -568,7 +568,7 @@ func TestLinearExplicitWildcardDeltaOnly(t *testing.T) {
 		require.NoError(t, err)
 		mustBlock(t, w2)
 
-		// Change from ["a", "b"] to ["a", "c"] - removing "b" and adding "c" simultaneously
+		// Change from ["a", "b"] to ["a", "c"]
 		setExplicitResources(t, c, node1, "a", "c")
 
 		resp2 := <-w2

--- a/pkg/cache/v3/linear_test.go
+++ b/pkg/cache/v3/linear_test.go
@@ -208,7 +208,7 @@ func hashResource(t *testing.T, resource types.Resource) string {
 
 func createWildcardDeltaWatch(t *testing.T, initialReq bool, c *LinearCache, w chan DeltaResponse) {
 	t.Helper()
-	sub := stream.NewDeltaSubscription(nil, nil, nil)
+	sub := stream.NewDeltaSubscription(nil, nil, nil, "")
 	req := &DeltaRequest{TypeUrl: testType}
 	if !initialReq {
 		req.ResponseNonce = "1"
@@ -222,7 +222,7 @@ func createWildcardDeltaWatch(t *testing.T, initialReq bool, c *LinearCache, w c
 }
 
 func subFromRequest(req *Request) stream.Subscription {
-	return stream.NewSotwSubscription(req.GetResourceNames())
+	return stream.NewSotwSubscription(req.GetResourceNames(), "")
 }
 
 // This method represents the expected behavior of client and servers regarding the request and the subscription.
@@ -235,7 +235,7 @@ func updateFromSotwResponse(resp Response, sub *stream.Subscription, req *Reques
 }
 
 func subFromDeltaRequest(req *DeltaRequest) stream.Subscription {
-	return stream.NewDeltaSubscription(req.GetResourceNamesSubscribe(), req.GetResourceNamesUnsubscribe(), req.GetInitialResourceVersions())
+	return stream.NewDeltaSubscription(req.GetResourceNamesSubscribe(), req.GetResourceNamesUnsubscribe(), req.GetInitialResourceVersions(), "")
 }
 
 func TestLinearInitialResources(t *testing.T) {

--- a/pkg/cache/v3/simple_test.go
+++ b/pkg/cache/v3/simple_test.go
@@ -54,7 +54,7 @@ func (group) ID(node *core.Node) string {
 }
 
 func subFromRequest(req *cache.Request) stream.Subscription {
-	return stream.NewSotwSubscription(req.GetResourceNames())
+	return stream.NewSotwSubscription(req.GetResourceNames(), "")
 }
 
 // This method represents the expected behavior of client and servers regarding the request and the subscription.
@@ -601,7 +601,7 @@ func TestAvertPanicForWatchOnNonExistentSnapshot(t *testing.T) {
 		ResourceNames: []string{"rtds"},
 		TypeUrl:       rsrc.RuntimeType,
 	}
-	ss := stream.NewSotwSubscription([]string{"rtds"})
+	ss := stream.NewSotwSubscription([]string{"rtds"}, "")
 	ss.SetReturnedResources(map[string]string{"cluster": "abcdef"})
 	responder := make(chan cache.Response)
 	_, err := c.CreateWatch(req, ss, responder)

--- a/pkg/cache/v3/subscription.go
+++ b/pkg/cache/v3/subscription.go
@@ -7,6 +7,7 @@ type watchSubscription struct {
 	returnedResources   map[string]string
 	subscribedResources map[string]struct{}
 	isWildcard          bool
+	clientNodeID        string
 }
 
 func (s watchSubscription) ReturnedResources() map[string]string {
@@ -21,9 +22,14 @@ func (s watchSubscription) IsWildcard() bool {
 	return s.isWildcard
 }
 
+func (s watchSubscription) ClientNodeID() string {
+	return s.clientNodeID
+}
+
 func newWatchSubscription(s Subscription) watchSubscription {
 	clone := watchSubscription{
 		isWildcard:          s.IsWildcard(),
+		clientNodeID:        s.ClientNodeID(),
 		returnedResources:   make(map[string]string, len(s.ReturnedResources())),
 		subscribedResources: make(map[string]struct{}, len(s.SubscribedResources())),
 	}

--- a/pkg/server/delta/v3/server.go
+++ b/pkg/server/delta/v3/server.go
@@ -218,7 +218,12 @@ func (s *server) processDelta(str stream.DeltaStream, reqCh <-chan *discovery.De
 				// We also set the subscription as wildcard based on its legacy meaning (no resource name sent in resource_names_subscribe).
 				// If the subscription starts with this legacy mode, adding new resources will not unsubscribe from wildcard.
 				// It can still be done by explicitly unsubscribing from "*"
-				watch.subscription = stream.NewDeltaSubscription(req.GetResourceNamesSubscribe(), req.GetResourceNamesUnsubscribe(), req.GetInitialResourceVersions())
+				watch.subscription = stream.NewDeltaSubscription(
+					req.GetResourceNamesSubscribe(),
+					req.GetResourceNamesUnsubscribe(),
+					req.GetInitialResourceVersions(),
+					req.GetNode().GetId(),
+				)
 			} else {
 				watch.Cancel()
 

--- a/pkg/server/sotw/v3/ads.go
+++ b/pkg/server/sotw/v3/ads.go
@@ -107,7 +107,7 @@ func (s *server) processADS(sw *streamWrapper, reqCh chan *discovery.DiscoveryRe
 				subscription.SetResourceSubscription(req.GetResourceNames())
 			} else {
 				s.opts.Logger.Debugf("[sotw ads] New subscription for type %s and stream %d", typeURL, sw.ID)
-				subscription = stream.NewSotwSubscription(req.GetResourceNames())
+				subscription = stream.NewSotwSubscription(req.GetResourceNames(), req.GetNode().GetId())
 			}
 
 			cancel, err := s.cache.CreateWatch(req, subscription, respChan)

--- a/pkg/server/sotw/v3/xds.go
+++ b/pkg/server/sotw/v3/xds.go
@@ -128,7 +128,7 @@ func (s *server) process(str stream.Stream, reqCh chan *discovery.DiscoveryReque
 				subscription.SetResourceSubscription(req.GetResourceNames())
 			} else {
 				s.opts.Logger.Debugf("[sotw] New subscription for type %s and stream %d", typeURL, sw.ID)
-				subscription = stream.NewSotwSubscription(req.GetResourceNames())
+				subscription = stream.NewSotwSubscription(req.GetResourceNames(), req.GetNode().GetId())
 			}
 
 			responder := make(chan cache.Response, 1)

--- a/pkg/server/stream/v3/subscription.go
+++ b/pkg/server/stream/v3/subscription.go
@@ -21,15 +21,18 @@ type Subscription struct {
 
 	// returnedResources contains the resources acknowledged by the client and the acknowledged versions.
 	returnedResources map[string]string
+
+	clientNodeID string
 }
 
 // newSubscription initializes a subscription state.
-func newSubscription(wildcard bool, initialResourceVersions map[string]string) Subscription {
+func newSubscription(wildcard bool, initialResourceVersions map[string]string, nodeID string) Subscription {
 	state := Subscription{
 		wildcard:                wildcard,
 		allowLegacyWildcard:     wildcard,
 		subscribedResourceNames: map[string]struct{}{},
 		returnedResources:       initialResourceVersions,
+		clientNodeID:            nodeID,
 	}
 
 	if initialResourceVersions == nil {
@@ -39,8 +42,8 @@ func newSubscription(wildcard bool, initialResourceVersions map[string]string) S
 	return state
 }
 
-func NewSotwSubscription(subscribed []string) Subscription {
-	sub := newSubscription(len(subscribed) == 0, nil)
+func NewSotwSubscription(subscribed []string, nodeID string) Subscription {
+	sub := newSubscription(len(subscribed) == 0, nil, nodeID)
 	sub.SetResourceSubscription(subscribed)
 	return sub
 }
@@ -90,8 +93,8 @@ func (s *Subscription) SetResourceSubscription(subscribed []string) {
 	s.subscribedResourceNames = subscribedResources
 }
 
-func NewDeltaSubscription(subscribed, unsubscribed []string, initialResourceVersions map[string]string) Subscription {
-	sub := newSubscription(len(subscribed) == 0, initialResourceVersions)
+func NewDeltaSubscription(subscribed, unsubscribed []string, initialResourceVersions map[string]string, nodeID string) Subscription {
+	sub := newSubscription(len(subscribed) == 0, initialResourceVersions, nodeID)
 	sub.UpdateResourceSubscriptions(subscribed, unsubscribed)
 	return sub
 }
@@ -167,6 +170,10 @@ func (s Subscription) IsWildcard() bool {
 // and their version
 func (s Subscription) ReturnedResources() map[string]string {
 	return s.returnedResources
+}
+
+func (s Subscription) ClientNodeID() string {
+	return s.clientNodeID
 }
 
 // SetReturnedResources sets a list of resource versions currently known by the client

--- a/pkg/server/stream/v3/subscription_test.go
+++ b/pkg/server/stream/v3/subscription_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestSotwSubscriptions(t *testing.T) {
 	t.Run("legacy mode properly handled", func(t *testing.T) {
-		sub := NewSotwSubscription([]string{})
+		sub := NewSotwSubscription([]string{}, "")
 		assert.True(t, sub.IsWildcard())
 
 		// Requests always set empty in legacy mode
@@ -35,7 +35,7 @@ func TestSotwSubscriptions(t *testing.T) {
 
 	t.Run("new wildcard mode from start", func(t *testing.T) {
 		// A resource is provided so the subscription was created in wildcard
-		sub := NewSotwSubscription([]string{"*"})
+		sub := NewSotwSubscription([]string{"*"}, "")
 		assert.True(t, sub.IsWildcard())
 		assert.Empty(t, sub.SubscribedResources())
 
@@ -73,7 +73,7 @@ func TestSotwSubscriptions(t *testing.T) {
 
 func TestDeltaSubscriptions(t *testing.T) {
 	t.Run("legacy mode properly handled", func(t *testing.T) {
-		sub := NewDeltaSubscription([]string{}, []string{}, map[string]string{"resource": "version"})
+		sub := NewDeltaSubscription([]string{}, []string{}, map[string]string{"resource": "version"}, "")
 		assert.True(t, sub.IsWildcard())
 		assert.Empty(t, sub.SubscribedResources())
 		assert.Equal(t, map[string]string{"resource": "version"}, sub.ReturnedResources())
@@ -102,7 +102,7 @@ func TestDeltaSubscriptions(t *testing.T) {
 
 	t.Run("new wildcard mode", func(t *testing.T) {
 		// A resource is provided so the subscription was created in wildcard
-		sub := NewDeltaSubscription([]string{"*"}, []string{}, map[string]string{"resource": "version"})
+		sub := NewDeltaSubscription([]string{"*"}, []string{}, map[string]string{"resource": "version"}, "")
 		assert.True(t, sub.IsWildcard())
 		assert.Empty(t, sub.SubscribedResources())
 


### PR DESCRIPTION
This PR adds the following to the linear cache api

```
func WithExplicitWildcardResources() LinearCacheOption {
```

Linear Cache API

```
func (cache *LinearCache) UpdateWilcardResourcesForNode(nodeId string, resources map[string]struct{}) error {
```