### PR TITLE
FCP-1434: Add resource-level wildcard support for snapshot cache

### DIFF
--- a/pkg/cache/internal/cached_resource.go
+++ b/pkg/cache/internal/cached_resource.go
@@ -87,8 +87,8 @@ func WithResourceTTL(ttl *time.Duration) CachedResourceOption {
 	return func(r *CachedResource) { r.ttl = ttl }
 }
 
-// WithOnDemandOnly marks the resource as on-demand only (for ODCDS support).
-func WithOnDemandOnly(onDemandOnly bool) CachedResourceOption {
+// OnDemandOnly marks the resource as on-demand only (for ODCDS support).
+func OnDemandOnly(onDemandOnly bool) CachedResourceOption {
 	return func(r *CachedResource) { r.onDemandOnly = onDemandOnly }
 }
 
@@ -131,8 +131,8 @@ func (c *CachedResource) HasTTL() bool {
 	return c.ttl != nil
 }
 
-// IsOnDemandOnly returns whether the resource is on-demand only.
-func (c *CachedResource) IsOnDemandOnly() bool {
+// OnDemandOnly returns whether the resource should be ignored by wildcard watches if not explicitly requested.
+func (c *CachedResource) OnDemandOnly() bool {
 	return c.onDemandOnly
 }
 

--- a/pkg/cache/internal/cached_resource.go
+++ b/pkg/cache/internal/cached_resource.go
@@ -40,7 +40,7 @@ type CachedResource struct {
 
 	marshalFunc func() (*anypb.Any, error)
 
-	// onDemandOnly indicates if this resource is only sent when explicitly requested (ODCDS support).
+	// onDemandOnly indicates if this resource is only sent when explicitly requested.
 	// When false (default), resource is sent to wildcard subscriptions.
 	// When true, resource is only sent when explicitly requested by name.
 	onDemandOnly bool
@@ -87,7 +87,7 @@ func WithResourceTTL(ttl *time.Duration) CachedResourceOption {
 	return func(r *CachedResource) { r.ttl = ttl }
 }
 
-// OnDemandOnly marks the resource as on-demand only (for ODCDS support).
+// OnDemandOnly marks the resource as on-demand only.
 func OnDemandOnly(onDemandOnly bool) CachedResourceOption {
 	return func(r *CachedResource) { r.onDemandOnly = onDemandOnly }
 }

--- a/pkg/cache/internal/cached_resource.go
+++ b/pkg/cache/internal/cached_resource.go
@@ -88,8 +88,6 @@ func WithResourceTTL(ttl *time.Duration) CachedResourceOption {
 }
 
 // WithOnDemandOnly marks the resource as on-demand only (for ODCDS support).
-// When false (default), resource is sent to wildcard subscriptions.
-// When true, resource is only sent when explicitly requested by name.
 func WithOnDemandOnly(onDemandOnly bool) CachedResourceOption {
 	return func(r *CachedResource) { r.onDemandOnly = onDemandOnly }
 }

--- a/pkg/cache/types/snapshot.go
+++ b/pkg/cache/types/snapshot.go
@@ -29,7 +29,7 @@ type SnapshotResource struct {
 	// Optional, if not set a version will be computed from the marshaled representation of the resource.
 	Version string
 
-	// Optional - marks resource as on-demand only (e.g. for OdCDS).
+	// Optional - marks resource as on-demand only.
 	// Only supported for the snapshot cache.
 	// When false (default), this resource is sent to all clients with wildcard subscriptions.
 	// When true, this resource is only sent when explicitly requested by name.

--- a/pkg/cache/types/snapshot.go
+++ b/pkg/cache/types/snapshot.go
@@ -29,7 +29,8 @@ type SnapshotResource struct {
 	// Optional, if not set a version will be computed from the marshaled representation of the resource.
 	Version string
 
-	// Optional - marks resource as on-demand only for ODCDS (On-Demand CDS).
+	// Optional - marks resource as on-demand only (e.g. for OdCDS).
+	// Only supported for the snapshot cache.
 	// When false (default), this resource is sent to all clients with wildcard subscriptions.
 	// When true, this resource is only sent when explicitly requested by name.
 	OnDemandOnly bool
@@ -41,7 +42,7 @@ func (r *SnapshotResource) AsCachedResource(cacheVersion string) *internal.Cache
 		internal.WithResourceTTL(r.TTL),
 		internal.WithResourceVersion(r.Version),
 		internal.WithMarshaledResource(r.Serialized),
-		internal.WithOnDemandOnly(r.OnDemandOnly),
+		internal.OnDemandOnly(r.OnDemandOnly),
 	)
 }
 

--- a/pkg/cache/types/snapshot.go
+++ b/pkg/cache/types/snapshot.go
@@ -28,6 +28,11 @@ type SnapshotResource struct {
 	// Resource-intrisic version. This version MUST change if the underlying resource changes to be sent to the data-plane.
 	// Optional, if not set a version will be computed from the marshaled representation of the resource.
 	Version string
+
+	// Optional - marks resource as on-demand only for ODCDS (On-Demand CDS).
+	// When false (default), this resource is sent to all clients with wildcard subscriptions.
+	// When true, this resource is only sent when explicitly requested by name.
+	OnDemandOnly bool
 }
 
 func (r *SnapshotResource) AsCachedResource(cacheVersion string) *internal.CachedResource {
@@ -35,7 +40,9 @@ func (r *SnapshotResource) AsCachedResource(cacheVersion string) *internal.Cache
 		internal.WithCacheVersion(cacheVersion),
 		internal.WithResourceTTL(r.TTL),
 		internal.WithResourceVersion(r.Version),
-		internal.WithMarshaledResource(r.Serialized))
+		internal.WithMarshaledResource(r.Serialized),
+		internal.WithOnDemandOnly(r.OnDemandOnly),
+	)
 }
 
 // From anypb code.

--- a/pkg/cache/types/snapshot_test.go
+++ b/pkg/cache/types/snapshot_test.go
@@ -28,8 +28,8 @@ func TestSnapshotWithWildcardFilter(t *testing.T) {
 	resources := typeSnapshot.GetResources()
 
 	require.Len(t, resources, 2)
-	assert.False(t, resources["wildcard-cluster"].IsOnDemandOnly())
-	assert.True(t, resources["on-demand-cluster"].IsOnDemandOnly())
+	assert.False(t, resources["wildcard-cluster"].OnDemandOnly())
+	assert.True(t, resources["on-demand-cluster"].OnDemandOnly())
 }
 
 func TestSnapshotResourceDefaultWildcard(t *testing.T) {
@@ -47,5 +47,5 @@ func TestSnapshotResourceDefaultWildcard(t *testing.T) {
 	resources := typeSnapshot.GetResources()
 
 	require.Len(t, resources, 1)
-	assert.False(t, resources["test-cluster"].IsOnDemandOnly())
+	assert.False(t, resources["test-cluster"].OnDemandOnly())
 }

--- a/pkg/cache/types/snapshot_test.go
+++ b/pkg/cache/types/snapshot_test.go
@@ -1,0 +1,65 @@
+// Copyright 2018 Envoyproxy Authors
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+package types_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
+	rsrc "github.com/envoyproxy/go-control-plane/pkg/resource/v3"
+	"github.com/envoyproxy/go-control-plane/pkg/test/resource/v3"
+)
+
+func TestSnapshotWithWildcardFilter(t *testing.T) {
+	// Test that OnDemandOnly flag is correctly stored and retrieved
+	wildcardCluster := resource.MakeCluster(resource.Ads, "wildcard-cluster")
+	onDemandCluster := resource.MakeCluster(resource.Ads, "on-demand-cluster")
+
+	snapshot, err := types.NewSnapshot("v1", map[string][]types.SnapshotResource{
+		rsrc.ClusterType: {
+			{Name: "wildcard-cluster", Resource: wildcardCluster, OnDemandOnly: false},
+			{Name: "on-demand-cluster", Resource: onDemandCluster, OnDemandOnly: true},
+		},
+	})
+	require.NoError(t, err)
+
+	typeSnapshot := snapshot.GetTypeSnapshot(rsrc.ClusterType)
+	resources := typeSnapshot.GetResources()
+
+	require.Len(t, resources, 2)
+	assert.False(t, resources["wildcard-cluster"].IsOnDemandOnly())
+	assert.True(t, resources["on-demand-cluster"].IsOnDemandOnly())
+}
+
+func TestSnapshotResourceDefaultWildcard(t *testing.T) {
+	// Test that SnapshotResource defaults to wildcard-eligible (OnDemandOnly=false)
+	cluster := resource.MakeCluster(resource.Ads, "test-cluster")
+
+	snapshot, err := types.NewSnapshot("v1", map[string][]types.SnapshotResource{
+		rsrc.ClusterType: {
+			{Name: "test-cluster", Resource: cluster},
+		},
+	})
+	require.NoError(t, err)
+
+	typeSnapshot := snapshot.GetTypeSnapshot(rsrc.ClusterType)
+	resources := typeSnapshot.GetResources()
+
+	require.Len(t, resources, 1)
+	assert.False(t, resources["test-cluster"].IsOnDemandOnly())
+}

--- a/pkg/cache/types/snapshot_test.go
+++ b/pkg/cache/types/snapshot_test.go
@@ -1,17 +1,3 @@
-// Copyright 2018 Envoyproxy Authors
-//
-//   Licensed under the Apache License, Version 2.0 (the "License");
-//   you may not use this file except in compliance with the License.
-//   You may obtain a copy of the License at
-//
-//       http://www.apache.org/licenses/LICENSE-2.0
-//
-//   Unless required by applicable law or agreed to in writing, software
-//   distributed under the License is distributed on an "AS IS" BASIS,
-//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-//   See the License for the specific language governing permissions and
-//   limitations under the License.
-
 package types_test
 
 import (

--- a/pkg/cache/v3/simple.go
+++ b/pkg/cache/v3/simple.go
@@ -212,7 +212,7 @@ func (cache *snapshotCache) sendHeartbeats(ctx context.Context, node string) {
 				resourcesToReturn = make(map[string]*internal.CachedResource, len(resources))
 				for _, res := range resources {
 					// Include wildcard-eligible resources for wildcard subscriptions (ODCDS support)
-					if !res.IsOnDemandOnly() {
+					if !res.OnDemandOnly() {
 						addResource(res)
 					}
 				}
@@ -522,7 +522,7 @@ func createResponse(snapshot ResourceSnapshot, watch ResponseWatch, ads bool) (*
 			changedResources = make(map[string]struct{}, len(resources))
 			for name, res := range resources {
 				// Include wildcard-eligible resources for wildcard subscriptions (ODCDS support)
-				if !res.IsOnDemandOnly() {
+				if !res.OnDemandOnly() {
 					if _, known := knownResources[name]; !known {
 						changedResources[name] = struct{}{}
 					}
@@ -559,7 +559,7 @@ func createResponse(snapshot ResourceSnapshot, watch ResponseWatch, ads bool) (*
 
 			if watch.subscription.IsWildcard() {
 				// For wildcard subscriptions: delete if resource is on-demand only AND not explicitly subscribed
-				if res.IsOnDemandOnly() {
+				if res.OnDemandOnly() {
 					if _, explicitlySubscribed := subscribedResources[name]; !explicitlySubscribed {
 						deletedResources = append(deletedResources, name)
 					}
@@ -588,7 +588,7 @@ func createResponse(snapshot ResourceSnapshot, watch ResponseWatch, ads bool) (*
 			returnedResources = make(map[string]string, len(resources))
 			for name, resource := range resources {
 				// Include wildcard-eligible resources for wildcard subscriptions (ODCDS support)
-				if !resource.IsOnDemandOnly() {
+				if !resource.OnDemandOnly() {
 					resourcesToReturn = append(resourcesToReturn, resource)
 					returnedResources[name] = version
 				}
@@ -735,7 +735,7 @@ func createDeltaResponse(snapshot ResourceSnapshot, watch DeltaResponseWatch, re
 	if watch.subscription.IsWildcard() {
 		for _, res := range resources {
 			// Include wildcard-eligible resources for wildcard subscriptions (ODCDS support)
-			if !res.IsOnDemandOnly() {
+			if !res.OnDemandOnly() {
 				if err := addIfChanged(res); err != nil {
 					return nil, fmt.Errorf("failed to compute resource version for %s: %w", res.Name, err)
 				}
@@ -763,7 +763,7 @@ func createDeltaResponse(snapshot ResourceSnapshot, watch DeltaResponseWatch, re
 
 		if watch.subscription.IsWildcard() {
 			// For wildcard subscriptions: delete if resource is on-demand only AND not explicitly subscribed
-			if res.IsOnDemandOnly() {
+			if res.OnDemandOnly() {
 				if _, explicitlySubscribed := subscribed[name]; !explicitlySubscribed {
 					deletedResources = append(deletedResources, name)
 					delete(returnedResources, name)

--- a/pkg/cache/v3/simple.go
+++ b/pkg/cache/v3/simple.go
@@ -211,7 +211,7 @@ func (cache *snapshotCache) sendHeartbeats(ctx context.Context, node string) {
 			if watch.subscription.IsWildcard() {
 				resourcesToReturn = make(map[string]*internal.CachedResource, len(resources))
 				for _, res := range resources {
-					// Include wildcard-eligible resources for wildcard subscriptions (ODCDS support)
+					// Include wildcard-eligible resources for wildcard subscriptions
 					if !res.OnDemandOnly() {
 						addResource(res)
 					}
@@ -521,7 +521,7 @@ func createResponse(snapshot ResourceSnapshot, watch ResponseWatch, ads bool) (*
 		if watch.subscription.IsWildcard() {
 			changedResources = make(map[string]struct{}, len(resources))
 			for name, res := range resources {
-				// Include wildcard-eligible resources for wildcard subscriptions (ODCDS support)
+				// Include wildcard-eligible resources for wildcard subscriptions
 				if res.OnDemandOnly() {
 					continue
 				}
@@ -559,20 +559,12 @@ func createResponse(snapshot ResourceSnapshot, watch ResponseWatch, ads bool) (*
 				continue
 			}
 
-			if watch.subscription.IsWildcard() {
-				// For wildcard subscriptions: delete if resource is on-demand only AND not explicitly subscribed
-				if !res.OnDemandOnly() {
-					continue
-				}
+			if watch.subscription.IsWildcard() && !res.OnDemandOnly() {
+				continue
+			}
 
-				if _, explicitlySubscribed := subscribedResources[name]; !explicitlySubscribed {
-					deletedResources = append(deletedResources, name)
-				}
-			} else {
-				// For non-wildcard subscriptions, check if resource is no longer watched
-				if _, explicitlySubscribed := subscribedResources[name]; !explicitlySubscribed {
-					deletedResources = append(deletedResources, name)
-				}
+			if _, explicitlySubscribed := subscribedResources[name]; !explicitlySubscribed {
+				deletedResources = append(deletedResources, name)
 			}
 		}
 
@@ -591,7 +583,7 @@ func createResponse(snapshot ResourceSnapshot, watch ResponseWatch, ads bool) (*
 			resourcesToReturn = make([]*internal.CachedResource, 0, len(resources))
 			returnedResources = make(map[string]string, len(resources))
 			for name, resource := range resources {
-				// Include wildcard-eligible resources for wildcard subscriptions (ODCDS support)
+				// Include wildcard-eligible resources for wildcard subscriptions
 				if !resource.OnDemandOnly() {
 					resourcesToReturn = append(resourcesToReturn, resource)
 					returnedResources[name] = version
@@ -606,7 +598,6 @@ func createResponse(snapshot ResourceSnapshot, watch ResponseWatch, ads bool) (*
 			if !ok {
 				continue
 			}
-			// Check if already added (for ODCDS: wildcard + explicit subscriptions)
 			if _, alreadyAdded := returnedResources[name]; !alreadyAdded {
 				resourcesToReturn = append(resourcesToReturn, resource)
 				returnedResources[name] = version
@@ -738,7 +729,7 @@ func createDeltaResponse(snapshot ResourceSnapshot, watch DeltaResponseWatch, re
 
 	if watch.subscription.IsWildcard() {
 		for _, res := range resources {
-			// Include wildcard-eligible resources for wildcard subscriptions (ODCDS support)
+			// Include wildcard-eligible resources for wildcard subscriptions
 			if !res.OnDemandOnly() {
 				if err := addIfChanged(res); err != nil {
 					return nil, fmt.Errorf("failed to compute resource version for %s: %w", res.Name, err)

--- a/pkg/cache/v3/snapshot.go
+++ b/pkg/cache/v3/snapshot.go
@@ -171,9 +171,10 @@ func (s *Snapshot) GetTypeSnapshot(typeURL string) types.TypeSnapshot {
 	resources := make([]types.SnapshotResource, 0, len(items))
 	for name, res := range items {
 		resources = append(resources, types.SnapshotResource{
-			Name:     name,
-			Resource: res.Resource,
-			TTL:      res.TTL,
+			Name:         name,
+			Resource:     res.Resource,
+			TTL:          res.TTL,
+			OnDemandOnly: false, // default to wildcard-eligible (backward compatibility with deprecated Snapshot)
 		})
 	}
 	// Error is only on wrong serialized resource type, which cannot occur here.

--- a/pkg/cache/v3/snapshot_test.go
+++ b/pkg/cache/v3/snapshot_test.go
@@ -192,15 +192,14 @@ func TestNewSnapshotBadType(t *testing.T) {
 	assert.Nil(t, snap)
 }
 
-func TestDeprecatedSnapshotDefaultWildcard(t *testing.T) {
-	// Test that deprecated Snapshot type defaults all resources to wildcard=true for backward compatibility
+func TestDeprecatedSnapshotDefaultOnDemandOnly(t *testing.T) {
+	// Test that deprecated Snapshot type defaults all resources to on-demand only=false for backward compatibility
 	snapshot := &cache.Snapshot{}
 	snapshot.Resources[types.Cluster] = cache.NewResources("v1", []types.Resource{testCluster})
 
 	typeSnapshot := snapshot.GetTypeSnapshot(rsrc.ClusterType)
 	resources := typeSnapshot.GetResources()
 
-	// Deprecated Snapshot should default all resources to wildcard-eligible for backward compatibility
 	require.Len(t, resources, 1)
 	assert.False(t, resources[clusterName].IsOnDemandOnly()) // false = wildcard-eligible
 }

--- a/pkg/cache/v3/snapshot_test.go
+++ b/pkg/cache/v3/snapshot_test.go
@@ -191,3 +191,16 @@ func TestNewSnapshotBadType(t *testing.T) {
 	require.Error(t, err)
 	assert.Nil(t, snap)
 }
+
+func TestDeprecatedSnapshotDefaultWildcard(t *testing.T) {
+	// Test that deprecated Snapshot type defaults all resources to wildcard=true for backward compatibility
+	snapshot := &cache.Snapshot{}
+	snapshot.Resources[types.Cluster] = cache.NewResources("v1", []types.Resource{testCluster})
+
+	typeSnapshot := snapshot.GetTypeSnapshot(rsrc.ClusterType)
+	resources := typeSnapshot.GetResources()
+
+	// Deprecated Snapshot should default all resources to wildcard-eligible for backward compatibility
+	require.Len(t, resources, 1)
+	assert.False(t, resources[clusterName].IsOnDemandOnly()) // false = wildcard-eligible
+}

--- a/pkg/cache/v3/snapshot_test.go
+++ b/pkg/cache/v3/snapshot_test.go
@@ -201,5 +201,5 @@ func TestDeprecatedSnapshotDefaultOnDemandOnly(t *testing.T) {
 	resources := typeSnapshot.GetResources()
 
 	require.Len(t, resources, 1)
-	assert.False(t, resources[clusterName].IsOnDemandOnly()) // false = wildcard-eligible
+	assert.False(t, resources[clusterName].OnDemandOnly()) // false = wildcard-eligible
 }


### PR DESCRIPTION
[Part 1](https://docs.google.com/document/d/1ZEFDgYpGyxlVtrx1BDKvvpaNpiBqw21FGpE286BX2II/edit?tab=t.0#heading=h.3ziedj27zhbq) of implementing explicit wildcard support for xds-control-plane.

## Context
We leverage the Snapshot Cache in go-control-plane, where delta for a node ID snapshot is proliferated to Envoys with that node ID when there is a change. This is acceptable in the current state where Fabric Proxy declares the destinations (clusters) it needs at start time in YAML.

The introduction of ODCDS makes the current state unpalatable, even though it is functional. The issue is that we do not want a mass proliferation of new clusters to all Envoys with node ID X when one pod with that node ID X requests a resource. Not solving this could create significant load on our control plane, especially for Fabric Proxy users with hundreds or thousands of destinations.

To solve this, we should add support for resource-level wildcard support for control plane. By default, a snapshot resource will be considered wildcard (OnDemandOnly = false) and proliferated to all Envoys with the relevant node ID. By contrast, we will allow certain resources to not be wildcard, allowing ODCDS clusters to only be proliferated on demand.

## Implementation details
This PR aims to make changes in a way that are fully backward compatible for Delta and SoTW. Users using the deprecated cache will have all resources default to wildcard-eligible. Users using the new cache will be able to specify `OnDemandOnly`. If not specified, then `OnDemandOnly=false`, meaning that the resource is wildcard-eligible.

```
snapshot, _ := types.NewSnapshot("v1", map[string][]types.SnapshotResource{
    resource.ClusterType: {
        // Wildcard-eligible: Default case
        {
            Name: "core-service",
            Resource: &cluster.Cluster{Name: "core-service"},
        },
        // Wildcard-eligible: Explicitly defined
        {
            Name: "core-service",
            Resource: &cluster.Cluster{Name: "core-service"},
            OnDemandOnly: false,
        },
        // On-demand only: sent only when explicitly requested
        {
            Name: "analytics-cluster",
            Resource: &cluster.Cluster{Name: "analytics-cluster"},
            OnDemandOnly: true,
        },
    },
})
```