### PR TITLE
fix linting issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ implements the discovery service APIs defined in
 
 ## Proto files
 
-The Go proto files are synced from the upstream Envoy repository (https://github.com/envoyproxy/envoy) on every upstream commit.
+The Go proto files are synced from the upstream Envoy repository (https://github.com/envoyproxy/envoy) on every upstream commit. Hello.
 
 Synchronization is triggered using the `envoy-sync.yaml` workflow.
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ implements the discovery service APIs defined in
 
 ## Proto files
 
-The Go proto files are synced from the upstream Envoy repository (https://github.com/envoyproxy/envoy) on every upstream commit. Hello.
+The Go proto files are synced from the upstream Envoy repository (https://github.com/envoyproxy/envoy) on every upstream commit.
 
 Synchronization is triggered using the `envoy-sync.yaml` workflow.
 

--- a/internal/example/resource.go
+++ b/internal/example/resource.go
@@ -168,8 +168,8 @@ func makeConfigSource() *core.ConfigSource {
 	return source
 }
 
-func GenerateSnapshot() *cache.Snapshot {
-	snap, _ := cache.NewSnapshot("1",
+func GenerateSnapshot() *cache.Snapshot { //nolint:staticcheck // example code uses deprecated API for backwards compatibility
+	snap, _ := cache.NewSnapshot("1", //nolint:staticcheck // example code uses deprecated API for backwards compatibility
 		map[resource.Type][]types.Resource{
 			resource.ClusterType:  {makeCluster(ClusterName)},
 			resource.RouteType:    {makeRoute(RouteName, ClusterName)},

--- a/pkg/cache/internal/cached_resource.go
+++ b/pkg/cache/internal/cached_resource.go
@@ -212,7 +212,7 @@ func (c *CachedResource) GetDeltaResource() (*discovery.Resource, error) {
 	}, nil
 }
 
-// hashResource will take a resource and create a SHA256 hash sum out of the marshaled bytes
+// hashResource will take a resource and create a SHA256 hash sum out of the marshaled bytes.
 func hashResource(resource []byte) string {
 	hasher := sha256.New()
 	hasher.Write(resource)

--- a/pkg/cache/internal/cached_resource_test.go
+++ b/pkg/cache/internal/cached_resource_test.go
@@ -155,18 +155,18 @@ func TestDeltaResource(t *testing.T) {
 		cacheVersion := "42"
 		defaultResourceVersion := hashResource(anySerialized.Value)
 
-		validate := func(t testing.TB, serialized *discovery.Resource, expectedVersion string) {
-			assert.Equal(t, c.Name, serialized.Name)
+		validate := func(tb testing.TB, serialized *discovery.Resource, expectedVersion string) {
+			assert.Equal(tb, c.Name, serialized.Name)
 			if expectedVersion != "" {
-				assert.Equal(t, expectedVersion, serialized.Version)
+				assert.Equal(tb, expectedVersion, serialized.Version)
 			} else {
-				assert.Equal(t, defaultResourceVersion, serialized.Version)
+				assert.Equal(tb, defaultResourceVersion, serialized.Version)
 			}
-			assert.Nil(t, serialized.Ttl)
-			require.NotEmpty(t, serialized.Resource.Value)
+			assert.Nil(tb, serialized.Ttl)
+			require.NotEmpty(tb, serialized.Resource.Value)
 
 			ret := &cluster.Cluster{}
-			require.NoError(t, serialized.Resource.UnmarshalTo(ret))
+			require.NoError(tb, serialized.Resource.UnmarshalTo(ret))
 			assert.Empty(t, cmp.Diff(c, ret, protocmp.Transform()))
 		}
 

--- a/pkg/cache/internal/cached_resource_test.go
+++ b/pkg/cache/internal/cached_resource_test.go
@@ -156,6 +156,7 @@ func TestDeltaResource(t *testing.T) {
 		defaultResourceVersion := hashResource(anySerialized.Value)
 
 		validate := func(tb testing.TB, serialized *discovery.Resource, expectedVersion string) {
+			tb.Helper()
 			assert.Equal(tb, c.Name, serialized.Name)
 			if expectedVersion != "" {
 				assert.Equal(tb, expectedVersion, serialized.Version)

--- a/pkg/cache/types/snapshot.go
+++ b/pkg/cache/types/snapshot.go
@@ -1,4 +1,4 @@
-package types //nolint:revive // var-naming: avoid meaningless package names
+package types
 
 import (
 	"fmt"
@@ -49,7 +49,7 @@ func (r *SnapshotResource) AsCachedResource(cacheVersion string) *internal.Cache
 // From anypb code.
 const urlPrefix = "type.googleapis.com/"
 
-// TypeURL returns the type of the included resources
+// TypeURL returns the type of the included resources.
 func (r *SnapshotResource) TypeURL() string {
 	if r.Serialized != nil {
 		return r.Serialized.GetTypeUrl()

--- a/pkg/cache/v3/snapshot.go
+++ b/pkg/cache/v3/snapshot.go
@@ -26,6 +26,7 @@ import (
 // Snapshot is an internally consistent snapshot of xDS resources.
 // Consistency is important for the convergence as different resource types
 // from the snapshot may be delivered to the proxy in arbitrary order.
+//
 // Deprecated: use types.Snapshot instead.
 type Snapshot struct {
 	Resources [types.UnknownType]Resources
@@ -35,6 +36,7 @@ var _ ResourceSnapshot = &Snapshot{}
 
 // NewSnapshot creates a snapshot from response types and a version.
 // The resources map is keyed off the type URL of a resource, followed by the slice of resource objects.
+//
 // Deprecated: use types.NewSnapshot or types.NewSnapshotFromTypeSnapshots instead.
 func NewSnapshot(version string, resources map[resource.Type][]types.Resource) (*Snapshot, error) {
 	out := Snapshot{}
@@ -53,6 +55,7 @@ func NewSnapshot(version string, resources map[resource.Type][]types.Resource) (
 
 // NewSnapshotWithTTLs creates a snapshot of ResourceWithTTLs.
 // The resources map is keyed off the type URL of a resource, followed by the slice of resource objects.
+//
 // Deprecated: use types.NewSnapshot or types.NewSnapshotFromTypeSnapshots instead.
 func NewSnapshotWithTTLs(version string, resources map[resource.Type][]types.ResourceWithTTL) (*Snapshot, error) {
 	out := Snapshot{}

--- a/pkg/client/sotw/v3/client_test.go
+++ b/pkg/client/sotw/v3/client_test.go
@@ -72,7 +72,7 @@ func testInitialFetch(ctx context.Context, snapCache cache.SnapshotCache, c clie
 			require.NoError(t, err)
 		})
 
-		snapshot, err := cache.NewSnapshot("1", map[resource.Type][]types.Resource{
+		snapshot, err := cache.NewSnapshot("1", map[resource.Type][]types.Resource{ //nolint:staticcheck // test code uses deprecated API
 			resource.ClusterType: {
 				&clusterv3.Cluster{Name: "cluster_1"},
 				&clusterv3.Cluster{Name: "cluster_2"},
@@ -109,7 +109,7 @@ func testNextFetch(ctx context.Context, snapCache cache.SnapshotCache, c client.
 			require.NoError(t, err)
 		})
 
-		snapshot, err := cache.NewSnapshot("2", map[resource.Type][]types.Resource{
+		snapshot, err := cache.NewSnapshot("2", map[resource.Type][]types.Resource{ //nolint:staticcheck // test code uses deprecated API
 			resource.ClusterType: {
 				&clusterv3.Cluster{Name: "cluster_2"},
 				&clusterv3.Cluster{Name: "cluster_4"},

--- a/pkg/integration/ttl_integration_test.go
+++ b/pkg/integration/ttl_integration_test.go
@@ -67,7 +67,7 @@ func TestTTLResponse(t *testing.T) {
 
 	oneSecond := time.Second
 	cla := &envoy_config_endpoint_v3.ClusterLoadAssignment{ClusterName: "resource"}
-	snap, _ := cache.NewSnapshotWithTTLs("1", map[resource.Type][]types.ResourceWithTTL{
+	snap, _ := cache.NewSnapshotWithTTLs("1", map[resource.Type][]types.ResourceWithTTL{ //nolint:staticcheck // test code uses deprecated API
 		resource.EndpointType: {{
 			Resource: cla,
 			TTL:      &oneSecond,

--- a/pkg/server/v3/delta_test.go
+++ b/pkg/server/v3/delta_test.go
@@ -141,6 +141,7 @@ func (stream *mockDeltaStream) Recv() (*discovery.DeltaDiscoveryRequest, error) 
 func makeMockDeltaStream(t *testing.T) *mockDeltaStream {
 	t.Helper()
 	ctx, cancel := context.WithCancel(context.Background())
+	_ = cancel // cancel is stored in mockDeltaStream for cleanup
 	return &mockDeltaStream{
 		t:      t,
 		ctx:    ctx,

--- a/pkg/server/v3/delta_test.go
+++ b/pkg/server/v3/delta_test.go
@@ -140,8 +140,7 @@ func (stream *mockDeltaStream) Recv() (*discovery.DeltaDiscoveryRequest, error) 
 
 func makeMockDeltaStream(t *testing.T) *mockDeltaStream {
 	t.Helper()
-	ctx, cancel := context.WithCancel(context.Background())
-	_ = cancel // cancel is stored in mockDeltaStream for cleanup
+	ctx, cancel := context.WithCancel(context.Background()) //nolint:gosec // cancel is stored in mockDeltaStream for cleanup
 	return &mockDeltaStream{
 		t:      t,
 		ctx:    ctx,

--- a/pkg/test/main/main.go
+++ b/pkg/test/main/main.go
@@ -339,7 +339,7 @@ func callEcho() (int, int) {
 		if err != nil {
 			return nil, err
 		}
-		return client.Do(req) //nolint:gosec
+		return client.Do(req)
 	}
 
 	// spawn requests

--- a/pkg/test/resource/v3/resource.go
+++ b/pkg/test/resource/v3/resource.go
@@ -735,7 +735,7 @@ func (ts *TestSnapshot) getPath() string {
 }
 
 // Generate produces a snapshot from the parameters.
-func (ts *TestSnapshot) Generate() *cache.Snapshot {
+func (ts *TestSnapshot) Generate() *cache.Snapshot { //nolint:staticcheck // test helper uses deprecated API
 	ts.currentPort = ts.BasePort
 
 	clusters := make([]types.Resource, ts.NumClusters)
@@ -779,7 +779,7 @@ func (ts *TestSnapshot) Generate() *cache.Snapshot {
 		extensions[i] = MakeExtensionConfig(Ads, extensionConfigName, routeName)
 	}
 
-	out, _ := cache.NewSnapshot(ts.Version, map[resource.Type][]types.Resource{
+	out, _ := cache.NewSnapshot(ts.Version, map[resource.Type][]types.Resource{ //nolint:staticcheck // test helper uses deprecated API
 		resource.EndpointType:        endpoints,
 		resource.ClusterType:         clusters,
 		resource.RouteType:           routes,


### PR DESCRIPTION
```
> make lint
level=info msg="golangci-lint has version 2.11.3 built with go1.26.1 from 6008b81b on 2026-03-10T10:25:44Z"
level=info msg="[config_reader] Config search paths: [./ /src / /root]"
level=info msg="[config_reader] Used config file .golangci.yml"
level=info msg="[config_reader] Module name \"github.com/envoyproxy/go-control-plane\""
level=info msg="[goenv] Read go env for 2.411708ms: map[string]string{\"GOCACHE\":\"/root/.cache/go-build\", \"GOROOT\":\"/usr/local/go\"}"
level=info msg="[lintersdb] Active 28 linters: [bodyclose contextcheck errcheck errorlint exptostd gocritic godot gofumpt goimports gosec govet ineffassign misspell modernize noctx nolintlint perfsprint revive staticcheck testifylint thelper tparallel unconvert unparam unused usestdlibvars usetesting whitespace]"
level=info msg="[loader] Go packages loading at mode 8767 (compiled_files|deps|files|imports|name|exports_file|types_sizes) took 11.60090213s"
level=info msg="[runner/filename_unadjuster] Pre-built 0 adjustments in 20.178584ms"
level=info msg="[linters_context/goanalysis] analyzers took 36.223803401s with top 10 stages: buildir: 14.011975097s, buildssa: 3.377115456s, revive: 3.134841413s, gosec: 2.237138208s, goimports: 1.962218167s, unparam: 1.30980108s, unconvert: 1.122483667s, printf: 861.739661ms, gofumpt: 580.62196ms, fact_deprecated: 545.858997ms"
level=info msg="[runner/exclusion_rules] Skipped 1 issues by rules: [Text: \"G101\", Path: \"pkg/test/resource/v3/secret.go\", Linters: \"gosec\"]"
level=info msg="[runner] Issues before processing: 135, after processing: 9"
level=info msg="[runner] Processors filtering stat (in/out): exclusion_paths: 135/135, nolint_filter: 22/10, source_code: 9/9, path_shortener: 9/9, severity-rules: 9/9, path_prettifier: 9/9, cgo: 135/135, filename_unadjuster: 135/135, exclusion_rules: 135/22, uniq_by_line: 10/9, max_per_file_from_linter: 9/9, max_same_issues: 9/9, path_absoluter: 135/135, invalid_issue: 135/135, path_relativity: 135/135, generated_file_filter: 135/135, fixer: 10/10, diff: 10/10, max_from_linter: 9/9, sort_results: 9/9"
level=info msg="[runner] processing took 9.418297ms with stages: generated_file_filter: 4.785624ms, nolint_filter: 3.319376ms, source_code: 909.709µs, exclusion_rules: 326.917µs, path_relativity: 41.334µs, exclusion_paths: 16.042µs, invalid_issue: 3.624µs, path_shortener: 3.333µs, uniq_by_line: 2.667µs, cgo: 2.667µs, sort_results: 2.292µs, max_same_issues: 1.25µs, path_absoluter: 1.167µs, fixer: 542ns, filename_unadjuster: 501ns, max_per_file_from_linter: 501ns, path_prettifier: 376ns, max_from_linter: 167ns, severity-rules: 125ns, diff: 83ns"
level=info msg="[runner] linters took 5.773601711s with stages: goanalysis_metalinter: 5.764129461s"
level=info msg="File cache stats: 6 entries of total size 55.1KiB"
pkg/cache/v3/snapshot.go:29:1: deprecatedComment: `Deprecated: ` notices should be in a dedicated paragraph, separated from the rest (gocritic)
// Deprecated: use types.Snapshot instead.
^
pkg/cache/v3/snapshot.go:38:1: deprecatedComment: `Deprecated: ` notices should be in a dedicated paragraph, separated from the rest (gocritic)
// Deprecated: use types.NewSnapshot or types.NewSnapshotFromTypeSnapshots instead.
^
pkg/cache/v3/snapshot.go:56:1: deprecatedComment: `Deprecated: ` notices should be in a dedicated paragraph, separated from the rest (gocritic)
// Deprecated: use types.NewSnapshot or types.NewSnapshotFromTypeSnapshots instead.
^
pkg/cache/internal/cached_resource.go:215:1: Comment should end in a period (godot)
// hashResource will take a resource and create a SHA256 hash sum out of the marshaled bytes
^
pkg/cache/types/snapshot.go:52:1: Comment should end in a period (godot)
// TypeURL returns the type of the included resources
^
pkg/server/v3/delta_test.go:143:35: G118: context cancellation function returned by WithCancel/WithTimeout/WithDeadline is not called (gosec)
        ctx, cancel := context.WithCancel(context.Background())
                                         ^
pkg/cache/types/snapshot.go:1:15: directive `//nolint:revive // var-naming: avoid meaningless package names` is unused for linter "revive" (nolintlint)
package types //nolint:revive // var-naming: avoid meaningless package names
              ^
pkg/test/main/main.go:342:25: directive `//nolint:gosec` is unused for linter "gosec" (nolintlint)
                return client.Do(req) //nolint:gosec
                                      ^
pkg/cache/internal/cached_resource_test.go:158:15: parameter testing.TB should have name tb (thelper)
                validate := func(t testing.TB, serialized *discovery.Resource, expectedVersion string) {
                            ^
9 issues:
* gocritic: 3
* godot: 2
* gosec: 1
* nolintlint: 2
* thelper: 1
level=info msg="Memory: 175 samples, avg is 225.4MB, max is 780.1MB"
level=info msg="Execution took 17.397393633s"
make: *** [lint] Error 1
```