### PR TITLE
cache: add LinearCache.GetResource for single-resource reads

### DIFF
--- a/pkg/cache/v3/linear.go
+++ b/pkg/cache/v3/linear.go
@@ -570,6 +570,26 @@ func (cache *LinearCache) GetResources() map[string]types.Resource {
 	return resources
 }
 
+// GetResource returns the resource stored under name and its version.
+// A nil resource with a nil error means the name is not in the cache.
+//
+// useResourceVersion controls the returned version:
+//   - if set to false versions reflect the cache version when the entry was added
+//   - if set to true versions are a stable property of the resource, with no regard to when it was added to the cache.
+func (cache *LinearCache) GetResource(name string, useResourceVersion bool) (types.Resource, string, error) {
+	cache.mu.RLock()
+	defer cache.mu.RUnlock()
+	r, ok := cache.resources[name]
+	if !ok {
+		return nil, "", nil
+	}
+	version, err := r.GetVersion(useResourceVersion)
+	if err != nil {
+		return nil, "", fmt.Errorf("linear cache: get version for %q: %w", name, err)
+	}
+	return r.GetRawResource().Resource, version, nil
+}
+
 // The implementations of sotw and delta watches handling is nearly identical. The main distinctions are:
 //   - handling of version in sotw when the request is the first of a subscription. Delta has a proper handling based on the request providing known versions.
 //   - building the initial resource versions in delta if they've not been computed yet.

--- a/pkg/cache/v3/linear_test.go
+++ b/pkg/cache/v3/linear_test.go
@@ -396,6 +396,35 @@ func TestLinearGetResources(t *testing.T) {
 	assert.Truef(t, reflect.DeepEqual(expectedResources, resources), "resources are not equal. got: %v want: %v", resources, expectedResources)
 }
 
+func TestLinearGetResource(t *testing.T) {
+	c := NewLinearCache(testType, WithVersionPrefix("instance1-"))
+	require.NoError(t, c.UpdateResource("a", testResource("a")))
+
+	t.Run("found cache version", func(t *testing.T) {
+		res, version, err := c.GetResource("a", false)
+		require.NoError(t, err)
+		require.NotNil(t, res)
+		assert.True(t, reflect.DeepEqual(testResource("a"), res))
+		assert.Equal(t, "instance1-1", version)
+	})
+
+	t.Run("found resource version", func(t *testing.T) {
+		_, cacheVersion, err := c.GetResource("a", false)
+		require.NoError(t, err)
+		_, resourceVersion, err := c.GetResource("a", true)
+		require.NoError(t, err)
+		assert.NotEmpty(t, resourceVersion)
+		assert.NotEqual(t, cacheVersion, resourceVersion, "content-hash version should differ from cache version")
+	})
+
+	t.Run("missing returns nil resource and nil error", func(t *testing.T) {
+		res, version, err := c.GetResource("missing", false)
+		require.NoError(t, err)
+		assert.Nil(t, res)
+		assert.Empty(t, version)
+	})
+}
+
 func TestLinearVersionPrefix(t *testing.T) {
 	c := NewLinearCache(testType, WithVersionPrefix("instance1-"))
 


### PR DESCRIPTION
## Summary

Adds `LinearCache.GetResource(name, useResourceVersion)` — a per-name accessor returning the resource and its version.

Motivation: callers building out-of-band synthetic responses (e.g. EDS subset re-filtering when an external authority assigns a new per-client routing token) need to read a specific entry from the cache without iterating `GetResources()` or going through a watch.

`useResourceVersion` controls the version flavor returned, matching the existing semantics on `CachedResource.GetVersion`:
- `false`: cache version at insertion (matches SOTW behavior)
- `true`: per-resource content hash (matches delta behavior)

A nil resource with a nil error means the name is not in the cache, matching the existing `return nil, nil` convention used elsewhere in the package. A non-nil error surfaces version-computation failures that would otherwise be silently dropped.

## Test plan
- [x] New `TestLinearGetResource` covering found (both version flavors) and missing cases
- [x] Existing `./pkg/cache/v3/` suite still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)