### PR TITLE
populate request node before callbacks in delta

### DIFF
--- a/pkg/server/delta/v3/server.go
+++ b/pkg/server/delta/v3/server.go
@@ -209,18 +209,18 @@ func (s *server) processDelta(str stream.DeltaStream, reqCh <-chan *discovery.De
 				return err
 			}
 
-			if s.callbacks != nil {
-				if err := s.callbacks.OnStreamDeltaRequest(streamID, req); err != nil {
-					return err
-				}
-			}
-
 			// The node information might only be set on the first incoming delta discovery request, so store it here so we can
 			// reset it on subsequent requests that omit it.
 			if req.GetNode() != nil {
 				node = req.GetNode()
 			} else {
 				req.Node = node
+			}
+
+			if s.callbacks != nil {
+				if err := s.callbacks.OnStreamDeltaRequest(streamID, req); err != nil {
+					return err
+				}
 			}
 
 			// type URL is required for ADS but is implicit for any other xDS stream

--- a/pkg/server/v3/delta_test.go
+++ b/pkg/server/v3/delta_test.go
@@ -381,6 +381,55 @@ func TestDeltaAggregatedHandlers(t *testing.T) {
 	}
 }
 
+func TestDeltaAggregatedCallbacksReceiveCachedNode(t *testing.T) {
+	config := makeMockConfigWatcher()
+	config.deltaResources = makeDeltaResources()
+	resp := makeMockDeltaStream(t)
+	defer resp.cancel()
+
+	callbackNodeIDs := make(chan string, 2)
+	s := server.NewServer(
+		context.Background(),
+		config,
+		server.CallbackFuncs{
+			StreamDeltaRequestFunc: func(_ int64, req *discovery.DeltaDiscoveryRequest) error {
+				callbackNodeIDs <- req.GetNode().GetId()
+				return nil
+			},
+		},
+	)
+
+	resp.recv <- &discovery.DeltaDiscoveryRequest{
+		Node:    node,
+		TypeUrl: rsrc.ListenerType,
+	}
+	resp.recv <- &discovery.DeltaDiscoveryRequest{
+		TypeUrl: rsrc.ClusterType,
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- s.DeltaAggregatedResources(resp)
+	}()
+
+	for _, want := range []string{node.GetId(), node.GetId()} {
+		select {
+		case got := <-callbackNodeIDs:
+			assert.Equal(t, want, got)
+		case <-time.After(1 * time.Second):
+			t.Fatalf("timed out waiting for callback node ID %q", want)
+		}
+	}
+
+	close(resp.recv)
+	select {
+	case err := <-errCh:
+		require.NoError(t, err)
+	case <-time.After(1 * time.Second):
+		t.Fatalf("timed out waiting for DeltaAggregatedResources to return")
+	}
+}
+
 func TestDeltaAggregateRequestType(t *testing.T) {
 	defer goleak.VerifyNone(t)
 	config := makeMockConfigWatcher()


### PR DESCRIPTION
In v1.38, envoy stopped sending the node id after the first request in a stream (the spec says it can do this). It expects the control-plane to save it the first time, and re-use it. The go-control-plane does this for STOW but not DELTA. 

This PR adds it to DELTA